### PR TITLE
Issue #210 handle instances of Þ or th in member name autoComplete

### DIFF
--- a/app/src/Controller/MembersController.php
+++ b/app/src/Controller/MembersController.php
@@ -755,7 +755,7 @@ class MembersController extends AppController
             ])
             ->select(["id", "sca_name"])
             ->limit(50);
-        $this->set(compact("query", "q"));
+        $this->set(compact("query", "q", "nq", "uq"));
     }
 
     public function emailTaken()

--- a/app/src/Controller/MembersController.php
+++ b/app/src/Controller/MembersController.php
@@ -660,7 +660,7 @@ class MembersController extends AppController
         if (!$member) {
             throw new \Cake\Http\Exception\NotFoundException();
         }
-        if($member->title){
+        if ($member->title) {
             $member->sca_name = $member->title . " " . $member->sca_name;
         }
         $this->Authorization->authorize($member);
@@ -699,7 +699,7 @@ class MembersController extends AppController
         if (!$member) {
             throw new \Cake\Http\Exception\NotFoundException();
         }
-        if($member->title){
+        if ($member->title) {
             $member->sca_name = $member->title . " " . $member->sca_name;
         }
         $this->Authorization->skipAuthorization();
@@ -733,12 +733,26 @@ class MembersController extends AppController
     public function autoComplete()
     {
         $q = $this->request->getQuery("q");
+        //detect th and replace with Þ
+        $nq = $q;
+        if (preg_match("/th/", $q)) {
+            $nq = str_replace("th", "Þ", $q);
+        }
+        //detect Þ and replace with th
+        $uq = $q;
+        if (preg_match("/Þ/", $q)) {
+            $uq = str_replace("Þ", "th", $q);
+        }
+
         $this->Authorization->skipAuthorization();
         $this->request->allowMethod(["get"]);
         $this->viewBuilder()->setClassName("Ajax");
         $query = $this->Members
             ->find("all")
-            ->where(["sca_name LIKE" => "%$q%", 'status <>' => Member::STATUS_DEACTIVATED])
+            ->where([
+                'status <>' => Member::STATUS_DEACTIVATED,
+                'OR' => [["sca_name LIKE" => "%$q%"], ["sca_name LIKE" => "%$nq%"], ["sca_name LIKE" => "%$uq%"]]
+            ])
             ->select(["id", "sca_name"])
             ->limit(50);
         $this->set(compact("query", "q"));

--- a/app/templates/Members/auto_complete.php
+++ b/app/templates/Members/auto_complete.php
@@ -1,7 +1,7 @@
 <?php
 foreach ($query as $sca_member) :
     //split up the word by the search term so it can be highlighted
-    $sca_name = preg_replace('/(' . $q . ')/i', '<span class="text-primary">$1</span>', h($sca_member->sca_name)); ?>
+    $sca_name = preg_replace('/(' . $q . '|' . $nq . '|' . $uq . ')/i', '<span class="text-primary">$1</span>', h($sca_member->sca_name)); ?>
 <li class="list-group-item" role="option" data-ac-value="<?= h($sca_member->id) ?>">
     <?= $sca_name ?></li>
 <?php endforeach; ?>


### PR DESCRIPTION
<!---

**PLEASE NOTE:**

This is only a issue tracker for issues related to the CakePHP Application Skeleton.
For CakePHP Framework issues please use this [issue tracker](https://github.com/cakephp/cakephp/issues).

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) guidelines when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
