### PR TITLE
Hierarchical security

### DIFF
--- a/app/plugins/Activities/src/Policy/AuthorizationPolicy.php
+++ b/app/plugins/Activities/src/Policy/AuthorizationPolicy.php
@@ -53,7 +53,7 @@ class AuthorizationPolicy extends BasePolicy
      */
     public function canRenew(KmpIdentityInterface $user, BaseEntity $entity, ...$optionalArgs): bool
     {
-        if ($entity->id == $user->getIdentifier()) {
+        if ($entity->member_id == $user->getIdentifier()) {
             return true;
         }
         $method = __FUNCTION__;
@@ -69,7 +69,7 @@ class AuthorizationPolicy extends BasePolicy
      */
     public function canMemberAuthorizations(KmpIdentityInterface $user, BaseEntity $entity, ...$optionalArgs): bool
     {
-        if ($entity->id == $user->getIdentifier()) {
+        if ($entity->member_id == $user->getIdentifier()) {
             return true;
         }
         $method = __FUNCTION__;
@@ -85,7 +85,7 @@ class AuthorizationPolicy extends BasePolicy
      */
     public function activityAuthorizations(KmpIdentityInterface $user, BaseEntity $entity, ...$optionalArgs): bool
     {
-        if ($entity->id == $user->getIdentifier()) {
+        if ($entity->member_id == $user->getIdentifier()) {
             return true;
         }
         $method = __FUNCTION__;

--- a/app/plugins/Activities/src/Policy/AuthorizationPolicy.php
+++ b/app/plugins/Activities/src/Policy/AuthorizationPolicy.php
@@ -37,7 +37,7 @@ class AuthorizationPolicy extends BasePolicy
      */
     public function canAdd(KmpIdentityInterface $user, BaseEntity|Table $entity, ...$optionalArgs): bool
     {
-        if ($entity->id == $user->getIdentifier()) {
+        if ($entity->member_id == $user->getIdentifier()) {
             return true;
         }
         $method = __FUNCTION__;

--- a/app/plugins/Awards/Assets/js/controllers/award-form-controller.js
+++ b/app/plugins/Awards/Assets/js/controllers/award-form-controller.js
@@ -33,6 +33,9 @@ class AwardsAwardForm extends Controller {
     connect() {
         if (this.formValueTarget.value && this.formValueTarget.value.length > 0) {
             this.items = JSON.parse(this.formValueTarget.value);
+            if (!Array.isArray(this.items)) {
+                this.items = [];
+            }
             this.items.forEach(item => {
                 //create a remove button
                 this.createListItem(item);

--- a/app/plugins/Officers/src/Controller/OfficersController.php
+++ b/app/plugins/Officers/src/Controller/OfficersController.php
@@ -150,6 +150,46 @@ class OfficersController extends AppController
         }
     }
 
+    public function memberOfficers($id, $state)
+    {
+        $newOfficer = $this->Officers->newEmptyEntity();
+        $newOfficer->member_id = $id;
+        $this->Authorization->authorize($newOfficer);
+
+        $officersQuery = $this->Officers->find()
+
+            ->contain(['Offices' => ["Departments"], 'Members', 'Branches'])
+            ->orderBY(["Officers.id" => "ASC"]);
+
+
+        switch ($state) {
+            case 'current':
+                $officersQuery = $this->Officers->addDisplayConditionsAndFields($officersQuery->find('current')->where(['Officers.member_id' => $id]), 'current');
+                break;
+            case 'upcoming':
+                $officersQuery = $this->Officers->addDisplayConditionsAndFields($officersQuery->find('upcoming')->where(['Officers.member_id' => $id]), 'upcoming');
+                break;
+            case 'previous':
+                $officersQuery = $this->Officers->addDisplayConditionsAndFields($officersQuery->find('previous')->where(['Officers.member_id' => $id]), 'previous');
+                break;
+        }
+
+        $page = $this->request->getQuery("page");
+        $limit = $this->request->getQuery("limit");
+        $paginate = [];
+        if ($page) {
+            $paginate['page'] = $page;
+        }
+        if ($limit) {
+            $paginate['limit'] = $limit;
+        }
+        //$paginate["limit"] = 5;
+        $officers = $this->paginate($officersQuery, $paginate);
+        $turboFrameId = $state;
+
+        $this->set(compact('officers', 'id', 'state'));
+    }
+
     public function branchOfficers($id, $state)
     {
         $newOfficer = $this->Officers->newEmptyEntity();

--- a/app/plugins/Officers/src/Model/Table/OfficersTable.php
+++ b/app/plugins/Officers/src/Model/Table/OfficersTable.php
@@ -300,6 +300,7 @@ class OfficersTable extends BaseTable
             'reports_to_branch_id',
             'deputy_to_office_id',
             'deputy_to_branch_id',
+            'Branches.name',
         ];
 
         $contain = [

--- a/app/plugins/Officers/src/Policy/OfficerPolicy.php
+++ b/app/plugins/Officers/src/Policy/OfficerPolicy.php
@@ -31,6 +31,23 @@ class OfficerPolicy extends BasePolicy
     }
 
     /**
+     * Check if $user can see all officers in a branch
+     *
+     * @param KmpIdentityInterface $user The user.
+     * @param BaseEntity $entity The entity.
+     * @param mixed ...$optionalArgs Optional arguments.
+     * @return bool
+     */
+    public function canMemberOfficers(KmpIdentityInterface $user, BaseEntity $entity, ...$optionalArgs)
+    {
+        if ($entity->member_id == $user->getIdentifier()) {
+            return true;
+        }
+        $method = __FUNCTION__;
+        return $this->_hasPolicy($user, $method, $entity);
+    }
+
+    /**
      * Check if $user can see all officers
      *
      * @param KmpIdentityInterface $user The user.

--- a/app/plugins/Officers/src/Policy/RostersControllerPolicy.php
+++ b/app/plugins/Officers/src/Policy/RostersControllerPolicy.php
@@ -16,13 +16,13 @@ class RostersControllerPolicy extends BasePolicy
     /**
      * Check if the user can view the reports
      * @param KmpIdentityInterface $user The user
-     * @param BaseEntity $entity The entity
+     * @param Array $entity The entity
      * @return bool
      */
-    public function canCreateRoster(KmpIdentityInterface $user, BaseEntity $entity, ...$optionalArgs): bool
+    public function canCreateRoster(KmpIdentityInterface $user, array $urlProps, ...$optionalArgs): bool
     {
         $method = __FUNCTION__;
-        return $this->_hasPolicy($user, $method, $entity);
+        return $this->_hasPolicyForUrl($user, $method, $urlProps);
     }
 
     public function canAdd(KmpIdentityInterface $user, BaseEntity|Table|array $entity, ...$optionalArgs): bool

--- a/app/plugins/Officers/src/View/Cell/MemberOfficersCell.php
+++ b/app/plugins/Officers/src/View/Cell/MemberOfficersCell.php
@@ -38,10 +38,6 @@ class MemberOfficersCell extends Cell
      */
     public function display($id)
     {
-        $offiersTable = TableRegistry::getTableLocator()->get("Officers.Officers");
-        $currentOfficers = $offiersTable->addDisplayConditionsAndFields($offiersTable->find('current')->where(['Officers.member_id' => $id]), "current")->toArray();
-        $upcomingOfficers = $offiersTable->addDisplayConditionsAndFields($offiersTable->find('upcoming')->where(['Officers.member_id' => $id]), "upcoming")->toArray();
-        $previousOfficers = $offiersTable->addDisplayConditionsAndFields($offiersTable->find('previous')->where(['Officers.member_id' => $id]), "previous")->toArray();
-        $this->set(compact('currentOfficers', 'upcomingOfficers', 'previousOfficers', 'id'));
+        $this->set(compact('id'));
     }
 }

--- a/app/plugins/Officers/templates/Officers/member_officers.php
+++ b/app/plugins/Officers/templates/Officers/member_officers.php
@@ -1,0 +1,94 @@
+<?php
+
+use Cake\Utility\Text;
+
+
+$linkTemplate = [
+    "type" => "button",
+    "verify" => true,
+    "label" => "Release",
+    "controller" => "Officers",
+    "action" => "release",
+    "id" => "officer_id",
+    "options" => [
+        "class" => "btn-sm btn btn-danger revoke-btn",
+        "data-bs-toggle" => "modal",
+        "data-bs-target" => "#releaseModal",
+        "data-controller" => "outlet-btn",
+        "data-action" => "click->outlet-btn#fireNotice",
+        "data-outlet-btn-btn-data-value" => '{ "id":{{id}} }',
+    ]
+];
+$editTemplate = [
+    "type" => "button",
+    "verify" => true,
+    "label" => "",
+    "plugin" => "Officers",
+    "controller" => "Officers",
+    "action" => "edit",
+    "id" => "officer_id",
+    "condition" => ["is_editable" => "1"],
+    "options" => [
+        "class" => "btn-sm btn btn-primary bi-pencil-fill edit-btn",
+        "data-bs-toggle" => "modal",
+        "data-bs-target" => "#editOfficerModal",
+        "data-controller" => "outlet-btn",
+        "data-action" => "click->outlet-btn#fireNotice",
+        "data-outlet-btn-btn-data-value" => '{ "id":{{id}}, "is_deputy":"{{office->is_deputy}}", "email_address":"{{email_address}}", "deputy_description":"{{deputy_description}}" }',
+    ],
+];
+$newWarrantTemplate = [
+    "type" => "postLink",
+    "verify" => true,
+    "label" => "Request Warrant",
+    "plugin" => "Officers",
+    "controller" => "Officers",
+    "action" => "requestWarrant",
+    "id" => "id",
+    "condition" => ["warrant_state" => "Missing"],
+    "options" => [
+        "confirm" => "Are you sure you want to request a new warrant for {{member->sca_name}}?",
+        "class" => "btn-sm btn btn-warning"
+    ],
+];
+
+$currentAndUpcomingTemplate = [
+    "Office" => "{{office->name}}{{: (deputy_description) }}",
+    "Branch" => "{{branch->name}}",
+    "Contact" => "<a href='mailto:{{email_address}}'>{{email_address}}</a>",
+    "Warrant Expires" => "warrant_state",
+    "Start Date" => "start_on_to_string",
+    "End Date" => "expires_on_to_string",
+    "Reports To" => "reports_to_list",
+    "Actions" => [
+        $editTemplate,
+        $newWarrantTemplate,
+        $linkTemplate,
+    ],
+];
+$previousTemplate = [
+    "Office" => "{{office->name}}{{: (deputy_description) }}",
+    "Branch" => "{{branch->name}}",
+    "Start Date" => "start_on_to_string",
+    "End Date" => "expires_on_to_string",
+    "Reason" => "revoked_reason",
+];
+
+if ($state == "previous") {
+    $columnTemplate = $previousTemplate;
+} else {
+    $columnTemplate = $currentAndUpcomingTemplate;
+}
+
+
+
+
+$tableData = [
+    "label" => __("Active"),
+    "id" => $turboFrameId,
+    "columns" => $columnTemplate,
+    "data" => $officers,
+    "usePagination" => true,
+];
+
+echo $this->element('turboSubTable', ['user' => $user, 'tableConfig' => $tableData]);

--- a/app/plugins/Officers/templates/cell/MemberOfficers/display.php
+++ b/app/plugins/Officers/templates/cell/MemberOfficers/display.php
@@ -1,123 +1,54 @@
 <?php
 $user = $this->request->getAttribute("identity");
-if (!empty($currentOfficers) || !empty($upcomingOfficers) || !empty($previousOfficers)) {
-    $linkTemplate = [
-        "type" => "link",
-        "verify" => true,
-        "authData" => "member",
-        "label" => "",
-        "controller" => "Members",
-        "action" => "view",
-        '?' => ['tab' => 'member-officers'],
-        "id" => "id",
-        "options" => ["class" => "btn-sm btn btn-secondary bi-binoculars-fill"],
-    ];
-    $editTemplate = [
-        "type" => "button",
-        "verify" => true,
-        "label" => "",
-        "plugin" => "Officers",
-        "controller" => "Officers",
-        "action" => "edit",
-        "id" => "officer_id",
-        "condition" => ["is_editable" => "1"],
-        "options" => [
-            "class" => "btn-sm btn btn-primary bi-pencil-fill edit-btn",
-            "data-bs-toggle" => "modal",
-            "data-bs-target" => "#editOfficerModal",
-            "data-controller" => "outlet-btn",
-            "data-action" => "click->outlet-btn#fireNotice",
-            "data-outlet-btn-btn-data-value" => '{ "id":{{id}}, "is_deputy":"{{office->is_deputy}}", "email_address":"{{email_address}}", "deputy_description":"{{deputy_description}}" }',
-        ],
-    ];
-    $releaseLinkTemplate = [
-        "type" => "button",
-        "verify" => true,
-        "label" => "Release",
-        "plugin" => "Officers",
-        "controller" => "Officers",
-        "action" => "release",
-        "id" => "officer_id",
-        "options" => [
-            "class" => "btn-sm btn btn-danger revoke-btn",
-            "data-bs-toggle" => "modal",
-            "data-bs-target" => "#releaseModal",
-            "data-controller" => "outlet-btn",
-            "data-action" => "click->outlet-btn#fireNotice",
-            "data-outlet-btn-btn-data-value" => '{ "id":{{id}} }',
-        ],
-    ];
-    $newWarrantTemplate = [
-        "type" => "postLink",
-        "verify" => true,
-        "label" => "Request Warrant",
-        "plugin" => "Officers",
-        "controller" => "Officers",
-        "action" => "requestWarrant",
-        "id" => "id",
-        "condition" => ["warrant_state" => "Missing"],
-        "options" => [
-            "confirm" => "Are you sure you want to request a new warrant for {{member->sca_name}}?",
-            "class" => "btn btn-warning btn-sm",
-        ],
-    ];
-    $currentTemplate = [
-        "Office" => "{{office->name}}{{: (deputy_description) }}",
-        "Contact" => "<a href='mailto:{{email_address}}'>{{email_address}}</a>",
-        "Warrant Expires" => "warrant_state",
-        "Branch" => "branch->name",
-        "Start Date" => "start_on_to_string",
-        "End Date" => "expires_on_to_string",
-
-        "Reports To" => "reports_to_list",
-        "Actions" => [
-            $editTemplate,
-            $newWarrantTemplate,
-            $releaseLinkTemplate
-        ],
-    ];
-    $previousTemplate = [
-        "Office" => "{{office->name}}{{: (deputy_description) }}",
-        "Branch" => "branch->name",
-        "Start Date" => "start_on_to_string",
-        "End Date" => "expires_on_to_string",
-    ];
-    echo $this->element('activeWindowTabs', [
-        'user' => $user,
-        'tabGroupName' => "officeTabs",
-        'tabs' => [
-            "active" => [
-                "label" => __("Active"),
-                "id" => "active-office",
-                "selected" => true,
-                "columns" => $currentTemplate,
-                "data" => $currentOfficers,
-            ],
-            "upcoming" => [
-                "label" => __("Upcoming"),
-                "id" => "upcoming-office",
-                "selected" => false,
-                "columns" => $currentTemplate,
-                "data" => $upcomingOfficers,
-            ],
-            "previous" => [
-                "label" => __("Previous"),
-                "id" => "previous-office",
-                "selected" => false,
-                "columns" => $previousTemplate,
-                "data" => $previousOfficers,
-            ]
-        ]
-    ]);
+if ($id == -1) {
+    $id = $user->id;
 } else {
-    echo "<p>No Offices assigned</p>";
+    $id = (int)$id;
 }
+?>
+
+<?php
+
+
+
+echo $this->element('turboActiveTabs', [
+    'user' => $user,
+    'tabGroupName' => "authorizationTabs",
+    'tabs' => [
+        "active" => [
+            "label" => __("Active"),
+            "id" => "current-officers",
+            "selected" => true,
+            "turboUrl" => $this->URL->build(["controller" => "Officers", "action" => "MemberOfficers", "plugin" =>
+            "Officers", $id, "current"])
+        ],
+        "upcoming" => [
+            "label" => __("Incoming"),
+            "id" => "upcoming-officers",
+            "selected" => false,
+            "turboUrl" => $this->URL->build(["controller" => "Officers", "action" => "MemberOfficers", "plugin" =>
+            "Officers", $id, "upcoming"])
+        ],
+        "previous" => [
+            "label" => __("Previous"),
+            "id" => "previous-officers",
+            "selected" => false,
+            "turboUrl" => $this->URL->build(["controller" => "Officers", "action" => "MemberOfficers", "plugin" =>
+            "Officers", $id, "previous"])
+        ]
+    ]
+]);
+?>
+
+<?php
 
 echo $this->KMP->startBlock("modals");
+
 echo $this->element('releaseModal', [
     'user' => $user,
 ]);
+
 echo $this->element('editModal', [
     'user' => $user,
 ]);
-$this->KMP->endBlock();
+$this->KMP->endBlock(); ?>

--- a/app/plugins/Officers/templates/cell/MemberOfficers/display.php
+++ b/app/plugins/Officers/templates/cell/MemberOfficers/display.php
@@ -71,7 +71,6 @@ if (!empty($currentOfficers) || !empty($upcomingOfficers) || !empty($previousOff
 
         "Reports To" => "reports_to_list",
         "Actions" => [
-            $linkTemplate,
             $editTemplate,
             $newWarrantTemplate,
             $releaseLinkTemplate
@@ -82,9 +81,6 @@ if (!empty($currentOfficers) || !empty($upcomingOfficers) || !empty($previousOff
         "Branch" => "branch->name",
         "Start Date" => "start_on_to_string",
         "End Date" => "expires_on_to_string",
-        "Actions" => [
-            $linkTemplate,
-        ],
     ];
     echo $this->element('activeWindowTabs', [
         'user' => $user,

--- a/app/plugins/Officers/templates/element/releaseModal.php
+++ b/app/plugins/Officers/templates/element/releaseModal.php
@@ -1,39 +1,38 @@
-<?php if ($user->checkCan("release", "Officers.Officers")) {
-    echo $this->Form->create(null, [
-        "url" => ["controller" => "Officers", "action" => "release"],
-        "data-controller" => "revoke-form",
-        "data-revoke-form-outlet-btn-outlet" => ".revoke-btn",
+<?php
+echo $this->Form->create(null, [
+    "url" => ["controller" => "Officers", "action" => "release"],
+    "data-controller" => "revoke-form",
+    "data-revoke-form-outlet-btn-outlet" => ".revoke-btn",
+]);
+echo $this->Modal->create("Release Office", [
+    "id" => "releaseModal",
+    "close" => true,
+]); ?>
+<fieldset>
+    <?php
+    echo $this->Form->control("id", [
+        "type" => "hidden",
+        "data-revoke-form-target" => "id",
     ]);
-    echo $this->Modal->create("Release Office", [
-        "id" => "releaseModal",
-        "close" => true,
-    ]); ?>
-    <fieldset>
-        <?php
-        echo $this->Form->control("id", [
-            "type" => "hidden",
-            "data-revoke-form-target" => "id",
-        ]);
-        echo $this->Form->control("revoked_reason", [
-            "label" => "Reason for Release",
-            "data-revoke-form-target" => "reason",
-            "data-action" => "input->revoke-form#checkReadyToSubmit",
-            "help" => "This message will be visible to the office holder."
-        ]);
+    echo $this->Form->control("revoked_reason", [
+        "label" => "Reason for Release",
+        "data-revoke-form-target" => "reason",
+        "data-action" => "input->revoke-form#checkReadyToSubmit",
+        "help" => "This message will be visible to the office holder."
+    ]);
 
-        ?>
-    </fieldset>
+    ?>
+</fieldset>
 <?php echo $this->Modal->end([
-        $this->Form->button("Submit", [
-            "class" => "btn btn-primary",
-            "data-revoke-form-target" => "submitBtn",
-        ]),
-        $this->Form->button("Close", [
-            "data-bs-dismiss" => "modal",
-            "type" => "button",
-        ]),
-    ]);
-    echo $this->Form->end();
-}
+    $this->Form->button("Submit", [
+        "class" => "btn btn-primary",
+        "data-revoke-form-target" => "submitBtn",
+    ]),
+    $this->Form->button("Close", [
+        "data-bs-dismiss" => "modal",
+        "type" => "button",
+    ]),
+]);
+echo $this->Form->end();
 
 ?>

--- a/app/templates/Branches/index.php
+++ b/app/templates/Branches/index.php
@@ -14,23 +14,23 @@ $this->KMP->endBlock();
 function branchHierachyTable($branches, $me, $parent_string = "")
 {
 ?>
-    <?php foreach ($branches as $branch) {
+<?php foreach ($branches as $branch) {
         $name = $parent_string . "/" . $branch->name; ?>
-        <tr>
-            <td><?= h($name) ?></td>
-            <td><?= h($branch->type) ?></td>
-            <td><?= h($branch->location) ?></td>
-            <td class="actions text-end text-nowrap">
-                <?= $me->Html->link(
+<tr>
+    <td><?= h($name) ?></td>
+    <td><?= h($branch->type) ?></td>
+    <td><?= h($branch->location) ?></td>
+    <td class="actions text-end text-nowrap">
+        <?= $me->Html->link(
                     __(""),
                     ["action" => "view", $branch->id],
                     ["title" => __("View"), "class" => "btn-sm btn btn-secondary bi bi-binoculars-fill", "data-turbo-frame" => "_top"],
                 ) ?>
-            </td>
-        </tr>
-        <?php if (!empty($branch->children)) { ?>
-            <?php branchHierachyTable($branch->children, $me, $name); ?>
-    <?php }
+    </td>
+</tr>
+<?php if (!empty($branch->children)) { ?>
+<?php branchHierachyTable($branch->children, $me, $name); ?>
+<?php }
     } ?>
 <?php
 }
@@ -66,6 +66,3 @@ function branchHierachyTable($branches, $me, $parent_string = "")
         </tbody>
     </table>
 </turbo-frame>
-
-
-<?php $this->append("script", $this->Html->script(["app/branches/index.js"])); ?>

--- a/app/templates/Branches/view.php
+++ b/app/templates/Branches/view.php
@@ -111,7 +111,7 @@ echo $this->KMP->startBlock("pageTitle") ?>
                 <td><?= h($member->sca_name) ?></td>
                 <td><?= $this->KMP->bool($member->age < 18, $this->Html) ?></td>
                 <td><?= h($member->membership_number) ?></td>
-                <td><?= h($member->membership_expires_on_to_string) ?>
+                <td><?= h($member->membership_expires_on) ?>
                 </td>
                 <td><?= h($member->status) ?></td>
                 <td class="actions text-end text-nowrap">

--- a/app/templates/Members/view_card_json.php
+++ b/app/templates/Members/view_card_json.php
@@ -2,10 +2,10 @@
 "member": <?= json_encode($member) ?>
 <?php
 
-use App\View\Cell\BasePluginCell;
+use App\Services\ViewCellRegistry;
 
-if (isset($pluginViewCells[BasePluginCell::PLUGIN_TYPE_JSON]) && !empty($pluginViewCells[BasePluginCell::PLUGIN_TYPE_JSON])) :
-    foreach ($pluginViewCells[BasePluginCell::PLUGIN_TYPE_JSON] as $cell) : ?>
+if (isset($pluginViewCells[ViewCellRegistry::PLUGIN_TYPE_JSON]) && !empty($pluginViewCells[ViewCellRegistry::PLUGIN_TYPE_JSON])) :
+    foreach ($pluginViewCells[ViewCellRegistry::PLUGIN_TYPE_JSON] as $cell) : ?>
 , "<?= $cell['id'] ?>": <?= $this->cell($cell["cell"], [$member->id]) ?>
 <?php endforeach;
 endif; ?>

--- a/app/webroot/js/controllers.js
+++ b/app/webroot/js/controllers.js
@@ -16954,6 +16954,9 @@ class AwardsAwardForm extends _hotwired_stimulus__WEBPACK_IMPORTED_MODULE_0__.Co
   connect() {
     if (this.formValueTarget.value && this.formValueTarget.value.length > 0) {
       this.items = JSON.parse(this.formValueTarget.value);
+      if (!Array.isArray(this.items)) {
+        this.items = [];
+      }
       this.items.forEach(item => {
         //create a remove button
         this.createListItem(item);

--- a/app/webroot/mix-manifest.json
+++ b/app/webroot/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/js/controllers.js": "/js/controllers.js?id=1575b4f1fffaf85254042ee61a333242",
+    "/js/controllers.js": "/js/controllers.js?id=a67bee25a45caa84cc5f753f95c3bb49",
     "/js/index.js": "/js/index.js?id=5625db7858d39db211ff8952352b1643",
     "/js/manifest.js": "/js/manifest.js?id=4284d3ae8c072a3820e817fb02a30347",
     "/js/core.js": "/js/core.js?id=915d26b8943aab8ee00bb1007486ba50",


### PR DESCRIPTION
This pull request introduces several changes across multiple files, focusing on policy updates, query enhancements, UI improvements, and code cleanup. Key updates include modifying authorization checks, extending query capabilities for recommendations, and redesigning officer-related templates for better usability.

### Policy Updates:
* Updated `AuthorizationPolicy` methods (`canAdd`, `canRenew`, `canMemberAuthorizations`, `activityAuthorizations`) to use `member_id` instead of `id` for user-entity matching. (`[[1]](diffhunk://#diff-807a189c0c40f4f65c6b6284661e6b0dedd3035829c29e0aa154cffef4c94331L40-R40)`, `[[2]](diffhunk://#diff-807a189c0c40f4f65c6b6284661e6b0dedd3035829c29e0aa154cffef4c94331L56-R56)`, `[[3]](diffhunk://#diff-807a189c0c40f4f65c6b6284661e6b0dedd3035829c29e0aa154cffef4c94331L72-R72)`, `[[4]](diffhunk://#diff-807a189c0c40f4f65c6b6284661e6b0dedd3035829c29e0aa154cffef4c94331L88-R88)`)
* Added `canMemberOfficers` method in `OfficerPolicy` to allow users to view officers based on `member_id`. (`[app/plugins/Officers/src/Policy/OfficerPolicy.phpR33-R49](diffhunk://#diff-4ad8231db9bb0fc1f01b04771377549e4cbec51e30365f4040221a26cc3aaaa5R33-R49)`)
* Modified `RostersControllerPolicy` to use `array` instead of `BaseEntity` for `canCreateRoster` method, improving flexibility. (`[app/plugins/Officers/src/Policy/RostersControllerPolicy.phpL19-R25](diffhunk://#diff-a131381201bd91d88391afa790decf697755a6f987f223f61e3752a208a27b95L19-R25)`)

### Query Enhancements:
* Extended `getRecommendationQuery` in `RecommendationsController` to include additional fields, joins, and filters, such as `branch_type`. (`[[1]](diffhunk://#diff-8a966b5149f0e02d3db0395b45d06d177937cb5dc1ecd631a34b38a5be3a6b21R1483-R1548)`, `[[2]](diffhunk://#diff-8a966b5149f0e02d3db0395b45d06d177937cb5dc1ecd631a34b38a5be3a6b21L1495-L1497)`, `[[3]](diffhunk://#diff-8a966b5149f0e02d3db0395b45d06d177937cb5dc1ecd631a34b38a5be3a6b21R1614-R1617)`)
* Added `Branches.name` to officer display conditions in `OfficersTable`. (`[app/plugins/Officers/src/Model/Table/OfficersTable.phpR303](diffhunk://#diff-6f49b04b8cf45641a06e8287dd78ba68a7f4ea7a2def779bd73f10e06cd82df9R303)`)

### UI Improvements:
* Redesigned `MemberOfficers` templates (`member_officers.php`, `display.php`) to use Turbo Frames for dynamic tab-based officer views. (`[[1]](diffhunk://#diff-146662250e385c72808bbd04084e726b903075f5ec1bb69cdfdf5ef52da04a30R1-R94)`, `[[2]](diffhunk://#diff-bfcfefbef2d6d81d973d06e8d65a05775a08615ddb2b279bdf346724e2a17411L3-R54)`)
* Simplified `releaseModal` element by removing unnecessary conditional checks. (`[[1]](diffhunk://#diff-4b77ea5d8649e4800f9e79e7d655e6e2b83e4b1ec71113d1b8f68b5466faad4fL1-R1)`, `[[2]](diffhunk://#diff-4b77ea5d8649e4800f9e79e7d655e6e2b83e4b1ec71113d1b8f68b5466faad4fL37)`)

### Code Cleanup:
* Removed unused script inclusion in `Branches/index.php`. (`[app/templates/Branches/index.phpL69-L71](diffhunk://#diff-509cc12f9ed27899478c847196415b51ab5ae68ca4853e4bd91e17dbaffae647L69-L71)`)
* Added validation in `award-form-controller.js` to ensure `items` is an array before processing. (`[app/plugins/Awards/Assets/js/controllers/award-form-controller.jsR36-R38](diffhunk://#diff-f8348dd3b2da0d1be7478e831cb17eb14d328c074f49d7f33ccf178c7bb2e471R36-R38)`)