### PR TITLE
feat: enhance recommendations and view cell logic for member visibili…

### DIFF
--- a/app/plugins/Awards/src/Controller/RecommendationsController.php
+++ b/app/plugins/Awards/src/Controller/RecommendationsController.php
@@ -1533,6 +1533,9 @@ class RecommendationsController extends AppController
             ->contain('Awards', function ($q) {
                 return $q->select(['id', 'abbreviation', 'branch_id', 'Levels.id', 'Levels.name']);
             })
+            ->contain('Awards.Levels', function ($q) {
+                return $q->select(['id', 'name']);
+            })
             ->join([
                 'AwardsForBranches' => [
                     'table' => 'awards_awards',

--- a/app/plugins/Awards/src/Policy/RecommendationsTablePolicy.php
+++ b/app/plugins/Awards/src/Policy/RecommendationsTablePolicy.php
@@ -34,8 +34,10 @@ class RecommendationsTablePolicy extends BasePolicy
             }
         }
         if (!empty($branchIds)) {
-            $query = $table->addBranchScopeQuery($query, $branchIds);
-        };
+            if ($branchIds[0] != -10000000) {
+                $query = $table->addBranchScopeQuery($query, $branchIds);
+            }
+        }
         if (!empty($approvaLevels)) {
             return $query->contain(['Awards.Levels'])->where(['Levels.name in' => $approvaLevels]);
         }

--- a/app/plugins/Awards/src/Services/AwardsViewCellProvider.php
+++ b/app/plugins/Awards/src/Services/AwardsViewCellProvider.php
@@ -47,18 +47,20 @@ class AwardsViewCellProvider
         ];
 
         // Recs For Member Cell - shows award recommendations received by a member
-        $cells[] = [
-            'type' => ViewCellRegistry::PLUGIN_TYPE_TAB,
-            'label' => 'Received Award Recs.',
-            'id' => 'recs-for-member',
-            'order' => 4,
-            'tabBtnBadge' => null,
-            'cell' => 'Awards.RecsForMember',
-            'validRoutes' => [
-                ['controller' => 'Members', 'action' => 'view', 'plugin' => null],
-                ['controller' => 'Members', 'action' => 'profile', 'plugin' => null]
-            ]
-        ];
+        // you can't see this if you are looking at your own profile
+        if ($urlParams['action'] != 'profile' && $user->id != $urlParams['pass'][0]) {
+            $cells[] = [
+                'type' => ViewCellRegistry::PLUGIN_TYPE_TAB,
+                'label' => 'Received Award Recs.',
+                'id' => 'recs-for-member',
+                'order' => 4,
+                'tabBtnBadge' => null,
+                'cell' => 'Awards.RecsForMember',
+                'validRoutes' => [
+                    ['controller' => 'Members', 'action' => 'view', 'plugin' => null],
+                ]
+            ];
+        }
         return $cells;
     }
 }

--- a/app/plugins/Awards/src/View/Cell/RecsForMemberCell.php
+++ b/app/plugins/Awards/src/View/Cell/RecsForMemberCell.php
@@ -41,6 +41,12 @@ class RecsForMemberCell extends Cell
         if ($id == -1) {
             $id = $this->request->getAttribute('identity')->getIdentifier();
         }
+        $currentUser = $this->request->getAttribute('identity');
+        if ($currentUser->id == $id && !$currentUser->checkCan('view', 'Awards.Recommendations')) {
+            $isEmpty = true;
+            $this->set(compact('isEmpty', 'id'));
+            return;
+        }
         $recommendationsTbl = TableRegistry::getTableLocator()->get("Awards.Recommendations");
         $isEmpty = $recommendationsTbl->find('all')->where(['member_id' => $id])->count() === 0;
         $this->set(compact('isEmpty', 'id'));


### PR DESCRIPTION
This pull request introduces changes to improve the handling of award recommendations in the `Awards` plugin. The updates enhance query logic, enforce access restrictions, and refine the display of recommendations based on user permissions and context.

### Query Enhancements:
* Added a new `contain` clause to the `getRecommendationQuery` method in `RecommendationsController` to include `Awards.Levels` with selected fields, improving the granularity of data retrieval.
* Updated the `scopeIndex` method in `RecommendationsTablePolicy` to add a conditional check for branch scope queries, ensuring invalid branch IDs are ignored.

### Access Control Improvements:
* Modified the `getViewCells` method in `AwardsViewCellProvider` to restrict the visibility of the "Received Award Recs." tab when viewing one's own profile. [[1]](diffhunk://#diff-53dd5f049d94377cda78484c58bd420f75e9ad894334079be21bfc02299b4953R50-R51) [[2]](diffhunk://#diff-53dd5f049d94377cda78484c58bd420f75e9ad894334079be21bfc02299b4953L59-R63)
* Updated the `display` method in `RecsForMemberCell` to prevent users from viewing their own recommendations if they lack the required permissions, setting the view to empty in such cases.