### PR TITLE
fix: remove status update for deactivated warrants during approval pr…

### DIFF
--- a/app/src/Services/WarrantManager/DefaultWarrantManager.php
+++ b/app/src/Services/WarrantManager/DefaultWarrantManager.php
@@ -179,7 +179,6 @@ class DefaultWarrantManager implements WarrantManagerInterface
                 //expire current warrants for the same entity_type entity_id member_id
                 $warrantTable->updateAll(
                     [
-                        'status' => Warrant::DEACTIVATED_STATUS,
                         'expires_on' => $warrant->start_on,
                         'revoked_reason' => 'New Warrant Approved',
                         'revoker_id' => $approver_id,


### PR DESCRIPTION
This pull request includes a minor change to the `approve` method in the `DefaultWarrantManager` class. The change removes the line of code that sets the `status` of existing warrants to `DEACTIVATED_STATUS` when approving a new warrant.

* [`app/src/Services/WarrantManager/DefaultWarrantManager.php`](diffhunk://#diff-fbc85d6f0e3336b256d78d506aaf10480254ec9dfb2cb0f39b77d37d47c25d80L182): Removed the line that deactivates the status of current warrants during the approval process.