### PR TITLE
Remove redundant code block before Data Filtering System section

### DIFF
--- a/docs/4.1-member-lifecycle.md
+++ b/docs/4.1-member-lifecycle.md
@@ -409,7 +409,6 @@ classDiagram
     Member --> DataAccessMatrix : implements
     Member --> MinorProtection : enforces
 ```
-```
 
 ### Data Filtering System
 


### PR DESCRIPTION
This pull request includes a small change to the `docs/4.1-member-lifecycle.md` file. The change removes an unnecessary empty code block from the `classDiagram` section.
