### PR TITLE
fix: update permission checks for viewing submitted and received awar…

### DIFF
--- a/app/plugins/Awards/src/Services/AwardsViewCellProvider.php
+++ b/app/plugins/Awards/src/Services/AwardsViewCellProvider.php
@@ -8,6 +8,7 @@ use App\KMP\StaticHelpers;
 use Awards\View\Cell\MemberSubmittedRecsCell;
 use Awards\View\Cell\RecsForMemberCell;
 use App\Services\ViewCellRegistry;
+use Cake\ORM\TableRegistry;
 
 /**
  * Awards View Cell Provider
@@ -25,30 +26,55 @@ class AwardsViewCellProvider
      */
     public static function getViewCells(array $urlParams, $user = null): array
     {
+        if (!$user) {
+            return [];
+        }
         // Check if plugin is enabled
         if (!StaticHelpers::pluginEnabled('Awards')) {
             return [];
         }
+        if (!$urlParams["controller"] == 'Members') {
+            return [];
+        }
+        //$emptyRecommendation = TableRegistry::getTableLocator()->get('Recommendations')->newEmptyEntity();
 
         $cells = [];
 
         // Member Submitted Recs Cell - shows award recommendations submitted by a member
-        $cells[] = [
-            'type' => ViewCellRegistry::PLUGIN_TYPE_TAB,
-            'label' => 'Submitted Award Recs.',
-            'id' => 'member-submitted-recs',
-            'order' => 3,
-            'tabBtnBadge' => null,
-            'cell' => 'Awards.MemberSubmittedRecs',
-            'validRoutes' => [
-                ['controller' => 'Members', 'action' => 'view', 'plugin' => null],
-                ['controller' => 'Members', 'action' => 'profile', 'plugin' => null]
-            ]
-        ];
+        // only show this if you are allowed to see recommendations OR this is your own profile
+        if (
+            $urlParams['action'] == 'profile'
+            || (
+                $urlParams["action"] == 'view'
+                && $user->id == $urlParams['pass'][0]
+            )
+            || ($user->can('ViewSubmittedByMember', 'Awards.Recommendations'))
+        ) {
+            $cells[] = [
+                'type' => ViewCellRegistry::PLUGIN_TYPE_TAB,
+                'label' => 'Submitted Award Recs.',
+                'id' => 'member-submitted-recs',
+                'order' => 3,
+                'tabBtnBadge' => null,
+                'cell' => 'Awards.MemberSubmittedRecs',
+                'validRoutes' => [
+                    ['controller' => 'Members', 'action' => 'view', 'plugin' => null],
+                    ['controller' => 'Members', 'action' => 'profile', 'plugin' => null]
+                ]
+            ];
+        }
 
         // Recs For Member Cell - shows award recommendations received by a member
         // you can't see this if you are looking at your own profile
-        if ($urlParams['action'] != 'profile' && ($urlParams["action"] == 'view' && $urlParams["controller"] == 'Members' && $user->id != $urlParams['pass'][0])) {
+        if (
+            $urlParams['action'] != 'profile'
+            && (
+                $urlParams["action"] == 'view'
+                && $user->id != $urlParams['pass'][0]
+            )
+            &&
+            ($user->can('ViewSubmittedForMember', 'Awards.Recommendations'))
+        ) {
             $cells[] = [
                 'type' => ViewCellRegistry::PLUGIN_TYPE_TAB,
                 'label' => 'Received Award Recs.',

--- a/app/plugins/Awards/src/View/Cell/MemberSubmittedRecsCell.php
+++ b/app/plugins/Awards/src/View/Cell/MemberSubmittedRecsCell.php
@@ -41,7 +41,7 @@ class MemberSubmittedRecsCell extends Cell
             $id = $this->request->getAttribute('identity')->getIdentifier();
         }
         $currentUser = $this->request->getAttribute('identity');
-        if ($currentUser->id != $id && !$currentUser->checkCan('view', 'Awards.Recommendations')) {
+        if ($currentUser->id != $id && !$currentUser->checkCan('ViewSubmittedByMember', 'Awards.Recommendations')) {
             return;
         }
         $recommendationsTbl = TableRegistry::getTableLocator()->get("Awards.Recommendations");

--- a/app/plugins/Awards/src/View/Cell/RecsForMemberCell.php
+++ b/app/plugins/Awards/src/View/Cell/RecsForMemberCell.php
@@ -42,7 +42,7 @@ class RecsForMemberCell extends Cell
             $id = $this->request->getAttribute('identity')->getIdentifier();
         }
         $currentUser = $this->request->getAttribute('identity');
-        if ($currentUser->id == $id && !$currentUser->checkCan('view', 'Awards.Recommendations')) {
+        if ($currentUser->id == $id && !$currentUser->checkCan('ViewSubmittedForMember', 'Awards.Recommendations')) {
             $isEmpty = true;
             $this->set(compact('isEmpty', 'id'));
             return;


### PR DESCRIPTION
This pull request refines the logic for displaying award recommendations by improving authorization checks and adding conditions to ensure proper behavior based on user roles and actions. It also includes minor updates to dependencies.

### Authorization improvements:

* **`AwardsViewCellProvider.php`**: Enhanced the `getViewCells` method to include stricter checks for user permissions and action contexts. Specifically, it ensures that users can only see recommendations if they are authorized or viewing their own profile. Added conditions to validate `urlParams` and user permissions for both "Submitted Award Recs." and "Received Award Recs." tabs. [[1]](diffhunk://#diff-53dd5f049d94377cda78484c58bd420f75e9ad894334079be21bfc02299b4953R29-R52) [[2]](diffhunk://#diff-53dd5f049d94377cda78484c58bd420f75e9ad894334079be21bfc02299b4953R65-R77)

* **`MemberSubmittedRecsCell.php`**: Updated permission checks to use `ViewSubmittedByMember` instead of the generic `view` permission, ensuring more granular control over viewing submitted recommendations.

* **`RecsForMemberCell.php`**: Adjusted permission checks to use `ViewSubmittedForMember` for validating access to received recommendations, improving alignment with the updated authorization logic.

### Dependency update:

* **`AwardsViewCellProvider.php`**: Added `Cake\ORM\TableRegistry` to the imports, preparing for potential future use of table registry functionality.
