### PR TITLE
fix: Update GatheringActivity and Gatherings models to handle non-re…

### DIFF
--- a/app/src/Model/Entity/GatheringActivity.php
+++ b/app/src/Model/Entity/GatheringActivity.php
@@ -32,11 +32,9 @@ class GatheringActivity extends BaseEntity
      * @var array<string, bool>
      */
     protected array $_accessible = [
-        'gathering_id' => true,
         'name' => true,
         'description' => true,
         'created' => true,
         'modified' => true,
-        'gathering' => true,
     ];
 }

--- a/app/src/Model/Table/GatheringsGatheringActivitiesTable.php
+++ b/app/src/Model/Table/GatheringsGatheringActivitiesTable.php
@@ -79,7 +79,6 @@ class GatheringsGatheringActivitiesTable extends Table
 
         $validator
             ->boolean('not_removable')
-            ->requirePresence('not_removable', true)
             ->allowEmptyString('not_removable', null, false);
 
         $validator

--- a/app/src/Model/Table/GatheringsTable.php
+++ b/app/src/Model/Table/GatheringsTable.php
@@ -297,9 +297,10 @@ class GatheringsTable extends Table
                 $newActivity = $gatheringsGatheringActivitiesTable->newEntity([
                     'gathering_id' => $gathering->id,
                     'gathering_activity_id' => $activityId,
-                    'sort_order' => $maxSortOrder,
-                    'not_removable' => $templateActivity->not_removable,
+                    'sort_order' => $maxSortOrder
                 ]);
+
+                $newActivity->not_removable = $templateActivity->not_removable;
                 $gatheringsGatheringActivitiesTable->save($newActivity);
             } else {
                 // Activity exists, update not_removable if template says it should be


### PR DESCRIPTION
This pull request makes targeted adjustments to the handling of entity accessibility, validation, and property assignment for gathering activities. The changes primarily focus on refining which fields are mass-assignable, updating validation rules, and ensuring correct property assignment during entity creation.

**Entity Accessibility Adjustments:**

* Removed `'gathering_id'` and `'gathering'` from the list of mass-assignable fields in the `GatheringActivity` entity to improve data integrity and prevent unintended assignment.

**Validation Rule Updates:**

* Modified the validation for the `not_removable` field in `GatheringsGatheringActivitiesTable` by removing the requirement for its presence, allowing more flexible entity creation.

**Property Assignment Fixes:**

* Updated the `syncTemplateActivities` method in `GatheringsTable` to set the `not_removable` property directly on the entity after creation, rather than as part of the initial data array, ensuring it is properly assigned and saved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal data validation and assignment logic for gathering activities.
  * Enhanced security controls around data handling.

This release contains internal improvements and does not introduce user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->