### PR TITLE
feat(GatheringWaivers): Update authorization logic for waiver uploads…

### DIFF
--- a/app/plugins/Waivers/src/Controller/GatheringWaiversController.php
+++ b/app/plugins/Waivers/src/Controller/GatheringWaiversController.php
@@ -2194,7 +2194,9 @@ class GatheringWaiversController extends AppController
             $gathering = $Gatherings->get($gatheringId);
 
             // Check authorization - user must be able to edit the gathering
-            $this->Authorization->authorize($gathering, 'uploadWaivers');
+            $gatheringWaiver = $this->GatheringWaivers->newEmptyEntity();
+            $gatheringWaiver->gathering = $gathering;
+            $this->Authorization->authorize($gatheringWaiver, 'uploadWaivers');
 
             // Verify all activities are assigned to this gathering
             $GatheringsGatheringActivities = $this->fetchTable('GatheringsGatheringActivities');


### PR DESCRIPTION
This pull request updates the authorization logic in the `attest` method of `GatheringWaiversController`. Instead of authorizing the `gathering` entity directly, the code now creates a new `gatheringWaiver` entity, associates it with the current gathering, and authorizes that entity for the `uploadWaivers` action. This change helps ensure that permissions are checked on the correct entity type for waiver uploads.

Authorization logic update:

* Changed authorization to check permissions on a newly created `gatheringWaiver` entity associated with the gathering, rather than the gathering itself, in the `attest` method of `GatheringWaiversController.php`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal authorization logic for consistency in the waiver attestation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->