### PR TITLE
fixing issue with dreamhost Mysql vs. dev database.

### DIFF
--- a/app/src/Controller/DataverseGridTrait.php
+++ b/app/src/Controller/DataverseGridTrait.php
@@ -314,16 +314,14 @@ trait DataverseGridTrait
                             // IS NOT NULL AND NOT EMPTY
                             $baseQuery->where(function ($exp) use ($qualifiedField) {
                                 return $exp->and([
-                                    $qualifiedField . ' IS NOT' => null,
-                                    $qualifiedField . ' !=' => '',
+                                    $qualifiedField . ' IS NOT' => null
                                 ]);
                             });
                         } elseif ($filterValue === 'no' || $filterValue === '0' || $filterValue === 0 || $filterValue === false) {
                             // IS NULL OR EMPTY
                             $baseQuery->where(function ($exp) use ($qualifiedField) {
                                 return $exp->or([
-                                    $qualifiedField . ' IS' => null,
-                                    $qualifiedField => '',
+                                    $qualifiedField . ' IS' => null
                                 ]);
                             });
                         }


### PR DESCRIPTION
This pull request makes a small adjustment to the filtering logic in the `processDataverseGrid` method. The update simplifies the conditions for checking if a field is not null or is null, by removing checks for empty string values.

- Simplified the filter conditions in `processDataverseGrid` by removing checks for empty string values, so filters now only check for `NULL` values instead of both `NULL` and empty strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified the "populated" filter logic to more accurately identify populated items, now including empty string values in its check.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->