### PR TITLE
fix: Update layout extension for changelog page to use default layout

### DIFF
--- a/app/templates/Pages/changelog.php
+++ b/app/templates/Pages/changelog.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * @var string|null $lastSyncedDate Date of last changelog sync
  */
 
-$this->extend('/layout/TwitterBootstrap/dashboard');
+$this->extend('/layout/default');
 
 echo $this->KMP->startBlock("title");
 echo $this->KMP->getAppSetting('KMP.ShortSiteTitle', 'KMP') . ': Changelog';


### PR DESCRIPTION
This pull request makes a small change to the page layout for the changelog. The layout has been switched from the Twitter Bootstrap dashboard template to the default layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual layout and styling of the changelog page to display with the default page template.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->