### PR TITLE
fix: MariaDB 11 FK constraint + waiver dashboard query

### DIFF
--- a/app/config/Migrations/20260206000001_AddHamletFieldsToBranches.php
+++ b/app/config/Migrations/20260206000001_AddHamletFieldsToBranches.php
@@ -28,8 +28,17 @@ class AddHamletFieldsToBranches extends AbstractMigration
                 'default' => null,
                 'limit' => 11,
                 'null' => true,
-                'signed' => false,
+                'signed' => true,
                 'after' => 'can_have_officers',
+                'comment' => 'Point of contact member for hamlet-mode branches',
+            ]);
+        } else {
+            // Ensure correct signedness if column was created in a prior partial run
+            $table->changeColumn('contact_id', 'integer', [
+                'default' => null,
+                'limit' => 11,
+                'null' => true,
+                'signed' => true,
                 'comment' => 'Point of contact member for hamlet-mode branches',
             ]);
         }

--- a/app/plugins/Waivers/src/Controller/GatheringWaiversController.php
+++ b/app/plugins/Waivers/src/Controller/GatheringWaiversController.php
@@ -2809,21 +2809,23 @@ class GatheringWaiversController extends AppController
         );
 
         // Batch 1: required waiver types by gathering (via activity assignments).
+        // gathering_id lives on the join table (gatherings_gathering_activities),
+        // not on gathering_activities itself, so we must join through Gatherings.
         $requiredRows = $GatheringActivityWaivers->find()
-            ->innerJoinWith('GatheringActivities', function ($q) use ($gatheringIds) {
+            ->innerJoinWith('GatheringActivities.Gatherings', function ($q) use ($gatheringIds) {
                 return $q->where([
-                    'GatheringActivities.gathering_id IN' => $gatheringIds,
-                    'GatheringActivities.deleted IS' => null,
+                    'Gatherings.id IN' => $gatheringIds,
                 ]);
             })
             ->where([
                 'GatheringActivityWaivers.deleted IS' => null,
+                'GatheringActivities.deleted IS' => null,
             ])
             ->select([
-                'gathering_id' => 'GatheringActivities.gathering_id',
+                'gathering_id' => 'Gatherings.id',
                 'waiver_type_id' => 'GatheringActivityWaivers.waiver_type_id',
             ])
-            ->distinct(['GatheringActivities.gathering_id', 'GatheringActivityWaivers.waiver_type_id'])
+            ->distinct(['Gatherings.id', 'GatheringActivityWaivers.waiver_type_id'])
             ->all();
 
         $requiredTypeIdsByGathering = [];

--- a/app/plugins/Waivers/tests/TestCase/Controller/GatheringWaiversControllerTest.php
+++ b/app/plugins/Waivers/tests/TestCase/Controller/GatheringWaiversControllerTest.php
@@ -244,6 +244,56 @@ class GatheringWaiversControllerTest extends HttpIntegrationTestCase
     }
 
     /**
+     * Test dashboard loads successfully
+     *
+     * Verifies the dashboard action and its internal queries work,
+     * including the _getGatheringsNeedingClosed query that joins
+     * GatheringActivityWaivers → GatheringActivities → Gatherings.
+     *
+     * @return void
+     * @uses \Waivers\Controller\GatheringWaiversController::dashboard()
+     */
+    public function testDashboard(): void
+    {
+        $this->get('/waivers/gathering-waivers/dashboard');
+        $this->assertResponseOk();
+    }
+
+    /**
+     * Test dashboard sets expected view variables
+     *
+     * @return void
+     * @uses \Waivers\Controller\GatheringWaiversController::dashboard()
+     */
+    public function testDashboardSetsViewVariables(): void
+    {
+        $this->get('/waivers/gathering-waivers/dashboard');
+        $this->assertResponseOk();
+
+        $statistics = $this->viewVariable('statistics');
+        $this->assertNotNull($statistics, 'Dashboard should set statistics');
+        $this->assertArrayHasKey('totalWaivers', $statistics);
+        $this->assertArrayHasKey('recentWaivers', $statistics);
+        $this->assertArrayHasKey('gatheringsMissingCount', $statistics);
+        $this->assertArrayHasKey('gatheringsNeedingCount', $statistics);
+
+        $this->assertNotNull($this->viewVariable('waiverTypesSummary'), 'Dashboard should set waiverTypesSummary');
+        $this->assertNotNull($this->viewVariable('complianceDays'), 'Dashboard should set complianceDays');
+    }
+
+    /**
+     * Test dashboard requires authentication
+     *
+     * @return void
+     */
+    public function testDashboardRequiresAuthentication(): void
+    {
+        $this->session(['Auth' => null]);
+        $this->get('/waivers/gathering-waivers/dashboard');
+        $this->assertRedirect();
+    }
+
+    /**
      * Temp file path for cleanup
      */
     private ?string $_testFilePath = null;


### PR DESCRIPTION
## Hot Patch — Two Related Fixes

### 1. Migration FK constraint error (MariaDB 11)
**Error:** `errno: 150 "Foreign key constraint is incorrectly formed"` on `branches.contact_id → members.id`

**Root cause:** The `AddHamletFieldsToBranches` migration created `contact_id` as `UNSIGNED` (`signed => false`), but `members.id` is `SIGNED`. MariaDB 11 strictly enforces signedness matching for FK constraints (MariaDB 10 was lenient).

**Fix:** Changed to `signed => true` and added a `changeColumn` fallback for environments where the column already exists from a prior partial migration run.

### 2. Waiver dashboard SQL error (production)
**Error:** `Column not found: 1054 Unknown column 'GatheringActivities.gathering_id'`

**Root cause:** The `_getGatheringsNeedingClosed()` query joined `GatheringActivityWaivers → GatheringActivities` and selected `GatheringActivities.gathering_id`, but `gathering_activities` is a catalog table with no `gathering_id` column. That column lives on the join table `gatherings_gathering_activities`.

**Fix:** Changed the join path to `GatheringActivities.Gatherings` (traversing the BelongsToMany) and selected `Gatherings.id` instead.

### 3. Dashboard test coverage
Added 3 tests for the dashboard action:
- `testDashboard` — exercises the full dashboard including the fixed query
- `testDashboardSetsViewVariables` — asserts key view vars are populated
- `testDashboardRequiresAuthentication` — verifies auth gate

All 21 waiver controller tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed waiver requirement tracking to properly retrieve gathering data, ensuring accurate waiver compliance records and requirements are displayed.

* **Tests**
  * Added comprehensive test coverage for dashboard access, including authentication verification and validation of waiver statistics display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->