### PR TITLE
fix: prevent Turbo from intercepting postLink form submissions in grids

### DIFF
--- a/app/templates/element/dataverse_table_row_actions.php
+++ b/app/templates/element/dataverse_table_row_actions.php
@@ -157,13 +157,18 @@ foreach ($actions as $action):
                 $confirmMessage = $processTemplate($action['confirmMessage'], $row);
             }
 
+            // Wrap in data-turbo="false" to prevent Turbo from intercepting
+            // the form submission. CakePHP's postLink uses requestSubmit()
+            // which fires a submit event Turbo would otherwise capture,
+            // causing a TurboFrameMissingError when the redirect response
+            // doesn't contain the expected turbo-frame.
+            echo '<div data-turbo="false" style="display:contents;">';
             echo $this->Form->postLink($label, $urlParams, [
                 'escape' => false,
                 'class' => $buttonClass,
                 'confirm' => $confirmMessage,
-                'data-turbo-frame' => '_top',
             ]);
-            echo ' ';
+            echo '</div> ';
             break;
 
         case 'link':


### PR DESCRIPTION
## Summary

Fixes the `TurboFrameMissingError` that occurs after clicking postLink actions (e.g. "Request Warrant") in grid row actions inside turbo-frames.

### Root Cause

CakePHP 5's `Form::postLink()` uses `requestSubmit()` to submit a hidden form. This fires a submit event that Turbo intercepts. Since the form is rendered inside a `<turbo-frame>`, Turbo follows the redirect and expects the response to contain the matching frame (`member-officers-grid-table`). However, the target page uses lazy-loading for grid content, so the inner frame isn't in the initial HTML — resulting in:

```
TurboFrameMissingError: The response (200) did not contain the expected
<turbo-frame id="member-officers-grid-table">
```

The previous `data-turbo-frame="_top"` attribute was placed on the `<a>` tag, which has no effect because Turbo processes the **form** submission (via `requestSubmit()`), not the link click.

### Fix

Wraps the postLink output in `<div data-turbo="false" style="display:contents;">`. When Turbo sees `data-turbo="false"` on the form's ancestor, it skips interception entirely, allowing a native POST + redirect + full page reload.

## Files Changed
- `app/templates/element/dataverse_table_row_actions.php`

## Testing
- All 2489 PHPUnit tests pass
- Affects all postLink actions in all grids (request warrant, delete, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed form submission behavior to prevent Turbo navigation interception on post-based actions, ensuring forms submit directly to the server and execute properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->