### PR TITLE
fix: show all recommendation states for own submissions and authorized viewers

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -3632,6 +3632,7 @@
             "version": "2.5.6",
             "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
             "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -3671,6 +3672,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3691,6 +3693,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3711,6 +3714,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3731,6 +3735,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3751,6 +3756,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3771,6 +3777,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3791,6 +3798,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3811,6 +3819,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3831,6 +3840,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3851,6 +3861,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3871,6 +3882,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3891,6 +3903,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3911,6 +3924,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -9867,7 +9881,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -9896,7 +9910,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
@@ -12474,6 +12488,7 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
             "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+            "dev": true,
             "license": "MIT",
             "optional": true
         },

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -4,7 +4,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "app",
             "hasInstallScript": true,
             "dependencies": {
                 "@fortawesome/fontawesome-free": "^7.2.0",
@@ -2309,7 +2308,6 @@
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
             "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2321,7 +2319,6 @@
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
             "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2332,7 +2329,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
             "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2345,448 +2341,6 @@
             "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-            "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
-            "cpu": [
-                "ppc64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "aix"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/android-arm": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-            "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/android-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-            "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/android-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-            "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-            "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/darwin-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-            "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-            "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-            "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-arm": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-            "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-            "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-ia32": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-            "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
-            "cpu": [
-                "ia32"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-loong64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-            "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
-            "cpu": [
-                "loong64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-            "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
-            "cpu": [
-                "mips64el"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-            "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
-            "cpu": [
-                "ppc64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-            "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
-            "cpu": [
-                "riscv64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-s390x": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-            "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
-            "cpu": [
-                "s390x"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-            "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-            "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-            "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-            "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-            "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-            "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openharmony"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/sunos-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-            "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-            "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-ia32": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-            "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
-            "cpu": [
-                "ia32"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-            "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
         },
         "node_modules/@exodus/bytes": {
             "version": "1.14.1",
@@ -4064,11 +3618,20 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@oxc-project/types": {
+            "version": "0.122.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+            "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
         "node_modules/@parcel/watcher": {
             "version": "2.5.6",
             "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
             "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -4108,7 +3671,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4129,7 +3691,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4150,7 +3711,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4171,7 +3731,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4192,7 +3751,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4213,7 +3771,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4234,7 +3791,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4255,7 +3811,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4276,7 +3831,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4297,7 +3851,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4318,7 +3871,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4339,7 +3891,6 @@
             "cpu": [
                 "ia32"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4360,7 +3911,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4573,24 +4123,10 @@
                 "url": "https://opencollective.com/popperjs"
             }
         },
-        "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-            "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-            "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
             "cpu": [
                 "arm64"
             ],
@@ -4599,12 +4135,15 @@
             "os": [
                 "android"
             ],
-            "peer": true
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-            "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
             "cpu": [
                 "arm64"
             ],
@@ -4613,12 +4152,15 @@
             "os": [
                 "darwin"
             ],
-            "peer": true
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-            "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
             "cpu": [
                 "x64"
             ],
@@ -4627,26 +4169,15 @@
             "os": [
                 "darwin"
             ],
-            "peer": true
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-            "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-            "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
             "cpu": [
                 "x64"
             ],
@@ -4655,12 +4186,15 @@
             "os": [
                 "freebsd"
             ],
-            "peer": true
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-            "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
+            "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
             "cpu": [
                 "arm"
             ],
@@ -4669,26 +4203,15 @@
             "os": [
                 "linux"
             ],
-            "peer": true
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-            "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-            "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
             "cpu": [
                 "arm64"
             ],
@@ -4697,12 +4220,15 @@
             "os": [
                 "linux"
             ],
-            "peer": true
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-            "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
+            "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
             "cpu": [
                 "arm64"
             ],
@@ -4711,40 +4237,15 @@
             "os": [
                 "linux"
             ],
-            "peer": true
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-            "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
-            "cpu": [
-                "loong64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-            "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
-            "cpu": [
-                "loong64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-            "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
             "cpu": [
                 "ppc64"
             ],
@@ -4753,54 +4254,15 @@
             "os": [
                 "linux"
             ],
-            "peer": true
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-            "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
-            "cpu": [
-                "ppc64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-            "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
-            "cpu": [
-                "riscv64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-            "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
-            "cpu": [
-                "riscv64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-            "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
             "cpu": [
                 "s390x"
             ],
@@ -4809,12 +4271,15 @@
             "os": [
                 "linux"
             ],
-            "peer": true
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-            "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
             "cpu": [
                 "x64"
             ],
@@ -4823,12 +4288,15 @@
             "os": [
                 "linux"
             ],
-            "peer": true
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-            "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
+            "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
             "cpu": [
                 "x64"
             ],
@@ -4837,26 +4305,15 @@
             "os": [
                 "linux"
             ],
-            "peer": true
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-            "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-            "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
             "cpu": [
                 "arm64"
             ],
@@ -4865,12 +4322,51 @@
             "os": [
                 "openharmony"
             ],
-            "peer": true
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-            "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
+            "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
+            "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
+            "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
             "cpu": [
                 "arm64"
             ],
@@ -4879,26 +4375,15 @@
             "os": [
                 "win32"
             ],
-            "peer": true
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-            "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
-            "cpu": [
-                "ia32"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "peer": true
-        },
-        "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-            "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
+            "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
             "cpu": [
                 "x64"
             ],
@@ -4907,20 +4392,16 @@
             "os": [
                 "win32"
             ],
-            "peer": true
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-            "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
-            "cpu": [
-                "x64"
-            ],
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
+            "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
             "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
             "peer": true
         },
         "node_modules/@sinclair/typebox": {
@@ -5005,7 +4486,6 @@
             "version": "0.10.1",
             "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
             "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -8274,9 +7754,7 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
             "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-            "dev": true,
             "license": "Apache-2.0",
-            "optional": true,
             "engines": {
                 "node": ">=8"
             }
@@ -8690,48 +8168,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/esbuild": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-            "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "peer": true,
-            "bin": {
-                "esbuild": "bin/esbuild"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.27.3",
-                "@esbuild/android-arm": "0.27.3",
-                "@esbuild/android-arm64": "0.27.3",
-                "@esbuild/android-x64": "0.27.3",
-                "@esbuild/darwin-arm64": "0.27.3",
-                "@esbuild/darwin-x64": "0.27.3",
-                "@esbuild/freebsd-arm64": "0.27.3",
-                "@esbuild/freebsd-x64": "0.27.3",
-                "@esbuild/linux-arm": "0.27.3",
-                "@esbuild/linux-arm64": "0.27.3",
-                "@esbuild/linux-ia32": "0.27.3",
-                "@esbuild/linux-loong64": "0.27.3",
-                "@esbuild/linux-mips64el": "0.27.3",
-                "@esbuild/linux-ppc64": "0.27.3",
-                "@esbuild/linux-riscv64": "0.27.3",
-                "@esbuild/linux-s390x": "0.27.3",
-                "@esbuild/linux-x64": "0.27.3",
-                "@esbuild/netbsd-arm64": "0.27.3",
-                "@esbuild/netbsd-x64": "0.27.3",
-                "@esbuild/openbsd-arm64": "0.27.3",
-                "@esbuild/openbsd-x64": "0.27.3",
-                "@esbuild/openharmony-arm64": "0.27.3",
-                "@esbuild/sunos-x64": "0.27.3",
-                "@esbuild/win32-arm64": "0.27.3",
-                "@esbuild/win32-ia32": "0.27.3",
-                "@esbuild/win32-x64": "0.27.3"
             }
         },
         "node_modules/escalade": {
@@ -10431,7 +9867,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -10460,7 +9896,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
@@ -12133,6 +11569,267 @@
                 "node": ">=6"
             }
         },
+        "node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "license": "MPL-2.0",
+            "peer": true,
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/lilconfig": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -12777,7 +12474,6 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
             "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-            "dev": true,
             "license": "MIT",
             "optional": true
         },
@@ -13657,9 +13353,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "version": "8.5.8",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -14999,49 +14695,38 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/rollup": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-            "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+        "node_modules/rolldown": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
+            "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@types/estree": "1.0.8"
+                "@oxc-project/types": "=0.122.0",
+                "@rolldown/pluginutils": "1.0.0-rc.12"
             },
             "bin": {
-                "rollup": "dist/bin/rollup"
+                "rolldown": "bin/cli.mjs"
             },
             "engines": {
-                "node": ">=18.0.0",
-                "npm": ">=8.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.59.0",
-                "@rollup/rollup-android-arm64": "4.59.0",
-                "@rollup/rollup-darwin-arm64": "4.59.0",
-                "@rollup/rollup-darwin-x64": "4.59.0",
-                "@rollup/rollup-freebsd-arm64": "4.59.0",
-                "@rollup/rollup-freebsd-x64": "4.59.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-                "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.59.0",
-                "@rollup/rollup-linux-arm64-musl": "4.59.0",
-                "@rollup/rollup-linux-loong64-gnu": "4.59.0",
-                "@rollup/rollup-linux-loong64-musl": "4.59.0",
-                "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-                "@rollup/rollup-linux-ppc64-musl": "4.59.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-                "@rollup/rollup-linux-riscv64-musl": "4.59.0",
-                "@rollup/rollup-linux-s390x-gnu": "4.59.0",
-                "@rollup/rollup-linux-x64-gnu": "4.59.0",
-                "@rollup/rollup-linux-x64-musl": "4.59.0",
-                "@rollup/rollup-openbsd-x64": "4.59.0",
-                "@rollup/rollup-openharmony-arm64": "4.59.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.59.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.59.0",
-                "@rollup/rollup-win32-x64-gnu": "4.59.0",
-                "@rollup/rollup-win32-x64-msvc": "4.59.0",
-                "fsevents": "~2.3.2"
+                "@rolldown/binding-android-arm64": "1.0.0-rc.12",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
             }
         },
         "node_modules/rrweb-cssom": {
@@ -16494,7 +16179,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
+            "devOptional": true,
             "license": "0BSD"
         },
         "node_modules/tsyringe": {
@@ -16849,17 +16534,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-            "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
+            "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "esbuild": "^0.27.0",
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.3",
-                "postcss": "^8.5.6",
-                "rollup": "^4.43.0",
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.4",
+                "postcss": "^8.5.8",
+                "rolldown": "1.0.0-rc.12",
                 "tinyglobby": "^0.2.15"
             },
             "bin": {
@@ -16876,9 +16560,10 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.1.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
-                "lightningcss": "^1.21.0",
                 "sass": "^1.70.0",
                 "sass-embedded": "^1.70.0",
                 "stylus": ">=0.54.8",
@@ -16891,13 +16576,16 @@
                 "@types/node": {
                     "optional": true
                 },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
                 "jiti": {
                     "optional": true
                 },
                 "less": {
-                    "optional": true
-                },
-                "lightningcss": {
                     "optional": true
                 },
                 "sass": {
@@ -16930,24 +16618,6 @@
             "license": "MIT",
             "peerDependencies": {
                 "vite": ">2.0.0-0"
-            }
-        },
-        "node_modules/vite/node_modules/fdir": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "picomatch": "^3 || ^4"
-            },
-            "peerDependenciesMeta": {
-                "picomatch": {
-                    "optional": true
-                }
             }
         },
         "node_modules/vm-browserify": {

--- a/app/plugins/Awards/src/Controller/RecommendationsController.php
+++ b/app/plugins/Awards/src/Controller/RecommendationsController.php
@@ -646,7 +646,9 @@ class RecommendationsController extends AppController
         $emptyRecommendation->requester_id = $memberId;
 
         $this->Authorization->authorize($emptyRecommendation, 'ViewSubmittedByMember');
-        $canViewHidden = $user->checkCan('ViewHidden', $emptyRecommendation);
+        // Members viewing their own submissions should always see all states
+        $isOwnSubmissions = ($user->id === $memberId);
+        $canViewHidden = $isOwnSubmissions || $user->checkCan('ViewHidden', $emptyRecommendation);
 
         // Build via service
         $built = $queryService->buildMemberSubmittedQuery($this->Recommendations, $memberId);
@@ -733,7 +735,8 @@ class RecommendationsController extends AppController
 
 
         $this->Authorization->authorize($emptyRecommendation, 'ViewSubmittedForMember');
-        $canViewHidden = $user->checkCan('ViewHidden', $emptyRecommendation);
+        // If the user can see this tab at all, they should see all states
+        $canViewHidden = true;
 
         // Build via service
         $built = $queryService->buildRecsForMemberQuery($this->Recommendations, $memberId);

--- a/app/plugins/Awards/src/Services/RecommendationFormService.php
+++ b/app/plugins/Awards/src/Services/RecommendationFormService.php
@@ -81,12 +81,13 @@ class RecommendationFormService
         $recommendation->domain_id = $recommendation->award->domain_id;
 
         // Lookup data
-        $awardsDomains = $recommendationsTable->Awards->Domains->find('list', limit: 200)->all();
-        $awardsLevels = $recommendationsTable->Awards->Levels->find('list', limit: 200)->all();
+        $awardsTable = $recommendationsTable->Awards->getTarget();
+        $awardsDomains = $awardsTable->Domains->find('list', limit: 200)->all();
+        $awardsLevels = $awardsTable->Levels->find('list', limit: 200)->all();
 
-        $branches = $this->buildBranchesList($recommendationsTable->Awards);
+        $branches = $this->buildBranchesList($awardsTable);
 
-        $awards = $recommendationsTable->Awards->find('all', limit: 200)
+        $awards = $awardsTable->find('all', limit: 200)
             ->select(['id', 'name', 'specialties'])
             ->where(['domain_id' => $recommendation->domain_id])
             ->all();
@@ -143,7 +144,7 @@ class RecommendationFormService
      */
     public function prepareBulkEditFormData(Table $recommendationsTable): array
     {
-        $branches = $this->buildBranchesList($recommendationsTable->Awards);
+        $branches = $this->buildBranchesList($recommendationsTable->Awards->getTarget());
 
         // Get gatherings data
         $gatheringsTable = TableRegistry::getTableLocator()->get('Gatherings');

--- a/app/plugins/Awards/templates/Recommendations/view.php
+++ b/app/plugins/Awards/templates/Recommendations/view.php
@@ -19,22 +19,9 @@ echo $this->KMP->startBlock("pageTitle") ?>
 <?php $this->KMP->endBlock() ?>
 <?= $this->KMP->startBlock("recordActions") ?>
 <?php if ($user->checkCan('edit', $recommendation)) : ?>
-    <button type="button" class="btn btn-primary btn-sm edit-rec" data-bs-toggle="modal" data-bs-target="#editModal"
-        data-controller="outlet-btn" data-action="click->outlet-btn#fireNotice"
-        data-outlet-btn-btn-data-value='{ "id":<?= $recommendation->id ?>}'>Edit</button>
-    <?php
-    echo $this->Form->postLink(
-        __("Delete"),
-        ["action" => "delete", $recommendation->id],
-        [
-            "confirm" => __(
-                "Are you sure you want to delete recommendation for {0}?",
-                h($recommendation->member_sca_name . ' about ' . $recommendation->award->name),
-            ),
-            "title" => __("Delete"),
-            "class" => "btn btn-danger btn-sm",
-        ],
-    ); ?>
+<button type="button" class="btn btn-primary btn-sm edit-rec" data-bs-toggle="modal" data-bs-target="#editModal"
+    data-controller="outlet-btn" data-action="click->outlet-btn#fireNotice"
+    data-outlet-btn-btn-data-value='{ "id":<?= $recommendation->id ?>}'>Edit</button>
 <?php endif; ?>
 <?php $this->KMP->endBlock() ?>
 <?php $this->KMP->startBlock("recordDetails") ?>
@@ -128,39 +115,39 @@ echo $this->KMP->startBlock("pageTitle") ?>
     <th scope="row"><?= __('Suggested Gatherings') ?></th>
     <td>
         <ul>
-            <?php foreach ($recommendation->gatherings as $gathering) : 
+            <?php foreach ($recommendation->gatherings as $gathering) :
                 $isCancelled = $gathering->cancelled_at !== null;
             ?>
-                <li>
-                    <?php if ($isCancelled): ?><span class="text-danger fw-bold">[CANCELLED]</span> <?php endif; ?>
-                    <?= $this->Html->link($gathering->name, ['controller' => 'Gatherings', 'action' => 'view', $gathering->public_id, 'plugin' => null], $isCancelled ? ['class' => 'text-danger'] : []) ?>
-                    <?php if ($recommendation->gathering_id == $gathering->id) {
+            <li>
+                <?php if ($isCancelled): ?><span class="text-danger fw-bold">[CANCELLED]</span> <?php endif; ?>
+                <?= $this->Html->link($gathering->name, ['controller' => 'Gatherings', 'action' => 'view', $gathering->public_id, 'plugin' => null], $isCancelled ? ['class' => 'text-danger'] : []) ?>
+                <?php if ($recommendation->gathering_id == $gathering->id) {
                         echo " (Plan to Give)";
                     } ?>
-                </li>
+            </li>
             <?php endforeach; ?>
         </ul>
     </td>
 </tr>
 <?php if (!empty($memberAttendanceGatherings)) : ?>
-    <tr>
-        <th scope="row"><?= __('Member\'s Planned Attendance') ?></th>
-        <td>
-            <ul>
-                <?php foreach ($memberAttendanceGatherings as $gathering) : ?>
-                    <li>
-                        <?= $this->Html->link($gathering->name, ['controller' => 'Gatherings', 'action' => 'view', $gathering->public_id, 'plugin' => null]) ?>
-                        <?php if ($gathering->start_date) : ?>
-                            <small class="text-muted">(<?= $gathering->start_date->format('M j, Y') ?>)</small>
-                        <?php endif; ?>
-                    </li>
-                <?php endforeach; ?>
-            </ul>
-            <small class="text-muted">
-                <i class="bi bi-info-circle"></i> Events the member has indicated they plan to attend
-            </small>
-        </td>
-    </tr>
+<tr>
+    <th scope="row"><?= __('Member\'s Planned Attendance') ?></th>
+    <td>
+        <ul>
+            <?php foreach ($memberAttendanceGatherings as $gathering) : ?>
+            <li>
+                <?= $this->Html->link($gathering->name, ['controller' => 'Gatherings', 'action' => 'view', $gathering->public_id, 'plugin' => null]) ?>
+                <?php if ($gathering->start_date) : ?>
+                <small class="text-muted">(<?= $gathering->start_date->format('M j, Y') ?>)</small>
+                <?php endif; ?>
+            </li>
+            <?php endforeach; ?>
+        </ul>
+        <small class="text-muted">
+            <i class="bi bi-info-circle"></i> Events the member has indicated they plan to attend
+        </small>
+    </td>
+</tr>
 <?php endif; ?>
 <tr>
     <th scope="row"><?= __('Call Into Court') ?></th>

--- a/app/src/Services/BackupService.php
+++ b/app/src/Services/BackupService.php
@@ -314,8 +314,9 @@ class BackupService
                     );
                 }
             } else {
-                // MySQL: disable FK checks for the duration of the import.
+                // MySQL: disable FK and CHECK constraints for the duration of the import.
                 $connection->execute('SET FOREIGN_KEY_CHECKS = 0');
+                $connection->execute('SET check_constraint_checks = 0');
 
                 foreach ($tablesToRestore as $tableName => $rows) {
                     $this->reportProgress($progressReporter, 'restoring_table', sprintf(
@@ -391,6 +392,7 @@ class BackupService
                 }
 
                 $connection->execute('SET FOREIGN_KEY_CHECKS = 1');
+                $connection->execute('SET check_constraint_checks = 1');
             }
 
             $this->reportProgress($progressReporter, 'finalizing', 'Finalizing restore.', [
@@ -422,6 +424,7 @@ class BackupService
             try {
                 if (!$isPostgres) {
                     $connection->execute('SET FOREIGN_KEY_CHECKS = 1');
+                    $connection->execute('SET check_constraint_checks = 1');
                 }
             } catch (Exception $ignored) {
             }

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     colorator (1.1.0)
     concurrent-ruby (1.3.5)
     em-websocket (0.5.3)
@@ -55,7 +55,7 @@ GEM
     mercenary (0.3.6)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (5.1.1)
+    public_suffix (7.0.5)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)


### PR DESCRIPTION
## Summary

Members viewing their own submitted recommendations now see all states including 'No Action', rather than having hidden states filtered out.

The 'Received Award Recs' tab also no longer filters hidden states, since access to the tab is already gated by `ViewSubmittedForMember` permission.

## Changes

- **Own submitted recs** (`memberSubmittedRecsGridData`): When `$user->id === $memberId`, `canViewHidden` is forced `true` so submitters always see all their own recommendations regardless of state.
- **Recs for member tab** (`recsForMemberGridData`): `canViewHidden` set to `true` unconditionally — if you passed the `ViewSubmittedForMember` authorization check, you should see everything.

## Testing

All verification checks pass (PHPUnit, Jest, Webpack, PHPCS, PHPStan).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recommendation grids now reliably include hidden submissions for the current user and in the member grid context so hidden items are shown as intended.

* **Chores**
  * Removed the Delete action from the recommendation view UI for editable records; Edit remains.
  * Minor template/layout formatting improvements.
  * Restore process now handles additional constraint checks during MySQL import for more reliable backups.
  * Development seed updated to use utf8mb4 character settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->