### PR TITLE
fix: disable source maps in production builds

### DIFF
--- a/app/webpack.mix.js
+++ b/app/webpack.mix.js
@@ -53,7 +53,7 @@ mix.setPublicPath('./webroot')
     .js('assets/js/index.js', 'webroot/js')
     .extract(['bootstrap', 'popper.js', '@hotwired/turbo', '@hotwired/stimulus', '@hotwired/stimulus-webpack-helpers'], 'webroot/js/core.js')
     .webpackConfig({
-        devtool: "source-map",
+        devtool: mix.inProduction() ? false : "source-map",
         resolve: {
             fallback: {
                 fs: false,
@@ -88,5 +88,8 @@ mix.setPublicPath('./webroot')
     .css('plugins/Waivers/assets/css/waivers.css', 'webroot/css/waivers.css')
     .css('plugins/Waivers/assets/css/waiver-upload.css', 'webroot/css/waiver-upload.css')
     .copyDirectory('node_modules/@fortawesome/fontawesome-free/webfonts', 'webroot/fonts')
-    .version()
-    .sourceMaps();
+    .version();
+
+if (!mix.inProduction()) {
+    mix.sourceMaps();
+}


### PR DESCRIPTION
Production builds (`npm run prod`) were emitting source map files because `devtool: "source-map"` and `.sourceMaps()` were unconditionally enabled in `webpack.mix.js`.

**Changes:**
- `devtool` now uses `mix.inProduction() ? false : "source-map"`

Dev builds continue to generate source maps as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized production build configuration to disable source maps in production environments, reducing bundle size and improving deployment efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->