### PR TITLE
fix(branches): scope members tab authorization to specific branch

### DIFF
--- a/app/src/Controller/BranchesController.php
+++ b/app/src/Controller/BranchesController.php
@@ -285,20 +285,34 @@ class BranchesController extends AppController
                 'Contacts' => function ($q) {
                     return $q->select(['id', 'public_id', 'sca_name']);
                 },
-                'Members' => function ($q) {
-                    return $q
-                        ->select([
-                            'id', 'sca_name', 'branch_id', 'membership_number',
-                            'membership_expires_on', 'status', 'birth_month', 'birth_year',
-                        ])
-                        ->orderBy(['sca_name' => 'ASC']);
-                },
             ])
             ->firstOrFail();
         if (!$branch) {
             throw new NotFoundException();
         }
         $this->Authorization->authorize($branch);
+
+        // Check if user can view members scoped to this specific branch
+        $user = $this->request->getAttribute('identity');
+        $canViewMembers = false;
+        if ($branch->can_have_members) {
+            $memberProbe = $this->fetchTable('Members')->newEmptyEntity();
+            $memberProbe->branch_id = $branch->id;
+            $canViewMembers = $user->checkCan('index', $memberProbe);
+        }
+
+        // Only load members when the user is authorized for this branch
+        if ($canViewMembers) {
+            $branch->members = $this->fetchTable('Members')->find()
+                ->select([
+                    'id', 'sca_name', 'branch_id', 'membership_number',
+                    'membership_expires_on', 'status', 'birth_month', 'birth_year',
+                ])
+                ->where(['Members.branch_id' => $branch->id])
+                ->orderBy(['sca_name' => 'ASC'])
+                ->toArray();
+        }
+
         // get the children for the branch
         $branch->children = $this->Branches
             ->find('children', for: $branch->id, direct: true)
@@ -313,9 +327,7 @@ class BranchesController extends AppController
             $branch_types[$branchType] = $branchType;
         }
 
-        // get a list of required offices and officers for the branch
-
-        $this->set(compact('branch', 'treeList', 'branch_types'));
+        $this->set(compact('branch', 'treeList', 'branch_types', 'canViewMembers'));
     }
 
     /**
@@ -372,20 +384,34 @@ class BranchesController extends AppController
                 'Contacts' => function ($q) {
                     return $q->select(['id', 'public_id', 'sca_name']);
                 },
-                'Members' => function ($q) {
-                    return $q
-                        ->select([
-                            'id', 'sca_name', 'branch_id', 'membership_number',
-                            'membership_expires_on', 'status', 'birth_month', 'birth_year',
-                        ])
-                        ->orderBy(['sca_name' => 'ASC']);
-                },
             ])
             ->firstOrFail();
         if (!$branch) {
             throw new NotFoundException();
         }
         $this->Authorization->authorize($branch);
+
+        // Check if user can view members scoped to this specific branch
+        $user = $this->request->getAttribute('identity');
+        $canViewMembers = false;
+        if ($branch->can_have_members) {
+            $memberProbe = $this->fetchTable('Members')->newEmptyEntity();
+            $memberProbe->branch_id = $branch->id;
+            $canViewMembers = $user->checkCan('index', $memberProbe);
+        }
+
+        // Only load members when the user is authorized for this branch
+        if ($canViewMembers) {
+            $branch->members = $this->fetchTable('Members')->find()
+                ->select([
+                    'id', 'sca_name', 'branch_id', 'membership_number',
+                    'membership_expires_on', 'status', 'birth_month', 'birth_year',
+                ])
+                ->where(['Members.branch_id' => $branch->id])
+                ->orderBy(['sca_name' => 'ASC'])
+                ->toArray();
+        }
+
         if ($this->request->is(['patch', 'post', 'put'])) {
             // Resolve contact public_id to internal id
             $contactPublicId = $this->request->getData('contact_id');
@@ -442,7 +468,7 @@ class BranchesController extends AppController
         $treeList = $this->Branches
             ->find('list')
             ->orderBy(['name' => 'ASC']);
-        $this->set(compact('branch', 'treeList'));
+        $this->set(compact('branch', 'treeList', 'canViewMembers'));
         // Mirror MembersController pattern: GET edit displays view template with modal
         if ($this->request->is('get')) {
             // Load children for the view template

--- a/app/templates/Branches/view.php
+++ b/app/templates/Branches/view.php
@@ -94,13 +94,9 @@ echo $this->KMP->startBlock('pageTitle') ?>
 </tr>
 <?php $this->KMP->endBlock() ?>
 <?php $this->KMP->startBlock('tabButtons') ?>
-<?php
-// Check if user can view members (PII requires permission)
-$canViewMembers = $branch->can_have_members && $user->checkCan('index', 'Members');
-?>
 <!-- Branch view tabs with ordering:
      Order 1: Officers plugin tab (if enabled)
-     Order 10: Members tab (primary data - requires permission)
+     Order 10: Members tab (primary data - requires branch-scoped permission)
      Order 15: Gatherings tab (branch events)
      Order 20: Sub-branches tab (secondary data) -->
 <?php if ($canViewMembers) : ?>


### PR DESCRIPTION
## Security Fix

The Members tab on Branch view had two authorization issues:

1. **Data leak**: Members were eagerly loaded via `contain(['Members'])` regardless of the user's permissions
2. **Wrong scope**: The authorization check used `checkCan('index', 'Members')` — a global table-level check that passes for any user with Members index permission on *any* branch

### Fix

- Creates a probe Member entity with the viewed branch's ID and checks `canIndex` against it, so `BasePolicy::_hasPolicy` properly validates the user's permission for that **specific branch**
- Members data is only loaded from the database when the user is authorized
- The `canViewMembers` flag is passed from the controller to the template (no more inline global check)
- Applied to both `view()` and `edit()` actions

### Files Changed
- `app/src/Controller/BranchesController.php` — branch-scoped auth check, conditional member loading
- `app/templates/Branches/view.php` — uses controller-provided flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Members authorization is now branch-scoped instead of global, ensuring users can only view members when they have authorization for that specific branch. The Members section is conditionally displayed based on individual branch permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->