### PR TITLE
fix: correct security cache invalidation for roles and permissions

### DIFF
--- a/app/src/KMP/PermissionsLoader.php
+++ b/app/src/KMP/PermissionsLoader.php
@@ -275,7 +275,7 @@ class PermissionsLoader
         // 3. Build Subquery with Validation Chain
         $subquery = $permissionsTable
             ->find()
-            ->cache('permissions_members' . $permissionId, 'permissions'); // Cache for performance
+            ->cache('permissions_members' . $permissionId, 'permissions_structure');
 
         // Apply comprehensive validation chain (same as getPermissions)
         $subquery = self::validPermissionClauses($subquery)

--- a/app/src/Model/Table/BaseTable.php
+++ b/app/src/Model/Table/BaseTable.php
@@ -82,6 +82,26 @@ class BaseTable extends Table
      */
     public function afterDelete($event, $entity, $options): void
     {
+        // Phase 1: Clear static cache entries
+        if (!empty($this::CACHES_TO_CLEAR)) {
+            foreach ($this::CACHES_TO_CLEAR as $cache) {
+                Cache::delete($cache[0], $cache[1]);
+            }
+        }
+
+        // Phase 2: Clear entity-ID-based cache entries
+        if (!empty($this::ID_CACHES_TO_CLEAR)) {
+            foreach ($this::ID_CACHES_TO_CLEAR as $cache) {
+                Cache::delete($cache[0] . $entity->id, $cache[1]);
+            }
+        }
+
+        // Phase 3: Clear cache groups entirely
+        if (!empty($this::CACHE_GROUPS_TO_CLEAR)) {
+            foreach ($this::CACHE_GROUPS_TO_CLEAR as $cache) {
+                Cache::clearGroup($cache);
+            }
+        }
         $this->logImpersonationAction('delete', $entity);
     }
 

--- a/app/src/Model/Table/MemberRolesTable.php
+++ b/app/src/Model/Table/MemberRolesTable.php
@@ -80,12 +80,22 @@ class MemberRolesTable extends BaseTable
      * @param mixed $options
      * @return void
      */
+    protected const CACHE_GROUPS_TO_CLEAR = ['security'];
+
     public function afterSave($event, $entity, $options): void
     {
+        parent::afterSave($event, $entity, $options);
         $memberId = $entity->member_id;
-        // Clear cached descendants and parents for the saved branch.
-        Cache::delete('permissions_policies' . $memberId);
-        Cache::delete('member_permissions' . $memberId);
+        Cache::delete('permissions_policies' . $memberId, 'member_permissions');
+        Cache::delete('member_permissions' . $memberId, 'member_permissions');
+    }
+
+    public function afterDelete($event, $entity, $options): void
+    {
+        parent::afterDelete($event, $entity, $options);
+        $memberId = $entity->member_id;
+        Cache::delete('permissions_policies' . $memberId, 'member_permissions');
+        Cache::delete('member_permissions' . $memberId, 'member_permissions');
     }
 
     /**


### PR DESCRIPTION
## Security Cache Invalidation Fix

Three bugs causing stale permission caches after role/permission changes:

### Bug 1 — MemberRolesTable wrong cache config
`Cache::delete()` was called without specifying the config, so it deleted from `'default'` instead of `'member_permissions'` where the data actually lives. Also added `afterDelete` handler and `CACHE_GROUPS_TO_CLEAR = ['security']`.

### Bug 2 — BaseTable::afterDelete missing cache clearing
Only logged impersonation — never cleared caches. Deleting a role, permission, or junction record left stale security data. Now mirrors `afterSave` cache invalidation logic.

### Bug 3 — PermissionsLoader non-existent cache config
Used `'permissions'` cache config (doesn't exist) for query caching on line 278, so results landed in `'default'` which is outside the `security` group. `Cache::clearGroup('security')` never cleared these entries. Changed to `'permissions_structure'` which is properly grouped.

### Files Changed
- `app/src/Model/Table/BaseTable.php` — afterDelete now clears caches
- `app/src/Model/Table/MemberRolesTable.php` — correct cache config + afterDelete + security group
- `app/src/KMP/PermissionsLoader.php` — use existing `permissions_structure` cache config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache invalidation strategy during record deletion to ensure permission and member role information remains properly synchronized.
  * Enhanced cache management mechanisms to increase system reliability and maintain data consistency across all application updates.
  * Refined permission caching to reduce potential conflicts and improve application responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->