### PR TITLE
fix(waivers): load upload CSS via AssetMix

### DIFF
--- a/app/plugins/Waivers/templates/GatheringWaivers/upload.php
+++ b/app/plugins/Waivers/templates/GatheringWaivers/upload.php
@@ -7,8 +7,8 @@
  * @var array $waiverStatusSummary
  */
 
-// Include wizard CSS
-echo $this->Html->css('Waivers./css/waiver-upload-wizard', ['block' => true]);
+// Include the built waiver upload stylesheet via AssetMix.
+$this->append('css', $this->AssetMix->css('waiver-upload'));
 
 $waiverTypesData = [];
 if (!empty($requiredWaiverTypes)) {


### PR DESCRIPTION
Summary:
- switch the waiver upload page to the built waiver-upload stylesheet via AssetMix
- stop generating the plugin-relative waiver-upload-wizard.css URL
- keep the page on the versioned /css asset pipeline

Root cause:
The template was using Html->css with a stale waiver-upload-wizard name, which generated /waivers/css/waiver-upload-wizard.css instead of the built /css/waiver-upload asset and caused 500s in production.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved stylesheet asset management for the waiver upload wizard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->