### PR TITLE
fix(assets): remove stale bootstrap icon paths

### DIFF
--- a/app/templates/layout/mobile_app.php
+++ b/app/templates/layout/mobile_app.php
@@ -85,9 +85,6 @@ $cardUrlForManifest = $currentUser ? $this->Url->build([
     <!-- CSS -->
     <?= $this->AssetMix->css('app') ?>
 
-    <!-- Bootstrap Icons -->
-    <link rel="stylesheet" href="/bootstrap_u_i/font/bootstrap-icons.min.css">
-
     <style>
     /* ============================================
            KMP Mobile PWA - Medieval Realm Theme

--- a/app/webroot/sw.js
+++ b/app/webroot/sw.js
@@ -1,15 +1,14 @@
 /**
- * KMP Service Worker v2.1.0
+ * KMP Service Worker v2.1.1
  * 
  * Features:
  * - Versioned cache with migration support
  * - Network-first with cache fallback strategy
  * - Client notification on updates
  * - Graceful migration from v1.x caches
- * - Bootstrap Icons precached for offline use
  */
 
-const SW_VERSION = '2.1.0';
+const SW_VERSION = '2.1.1';
 const CACHE_NAME = `kmp-mobile-v${SW_VERSION}`;
 
 // Old cache names to migrate from
@@ -25,11 +24,7 @@ const PRECACHE_URLS = [
     '/css/app.css',
     '/js/core.js',
     '/js/index.js',
-    '/js/controllers.js',
-    // Bootstrap Icons for offline use
-    '/bootstrap_u_i/font/bootstrap-icons.min.css',
-    '/bootstrap_u_i/font/fonts/bootstrap-icons.woff2',
-    '/bootstrap_u_i/font/fonts/bootstrap-icons.woff'
+    '/js/controllers.js'
 ];
 
 /**


### PR DESCRIPTION
Summary:
- remove the broken BootstrapUI icon stylesheet include from the mobile layout
- remove the same stale BootstrapUI asset URLs from the service worker precache list
- bump the service worker version so clients refresh away from the dead paths

Root cause:
The mobile layout and service worker still referenced BootstrapUI asset paths under /bootstrap_u_i, but the app already loads icons through app.css and those stale local URLs were returning 500s in production.
