### PR TITLE
fix: preserve keyboard selections in awards public submit

### DIFF
--- a/app/assets/js/controllers/auto-complete-controller.js
+++ b/app/assets/js/controllers/auto-complete-controller.js
@@ -412,6 +412,28 @@ class AutoComplete extends Controller {
         option.scrollIntoView({ behavior: "auto", block: "nearest" })
     }
 
+    cancelPendingInputChange() {
+        if (typeof this.onInputChange?.cancel === "function") {
+            this.onInputChange.cancel()
+        }
+    }
+
+    commitExactTextMatch() {
+        const newValue = this.inputTarget.value
+        const option = this._selectOptions.find(option => option.text == newValue && option.enabled != false)
+        if (!option) {
+            this.value = ""
+            return false
+        }
+
+        this.cancelPendingInputChange()
+        this.value = option.value
+        this.fireChangeEvent(String(option.value), option.text, this.resolveSelectionTarget(option))
+        this.hideAndRemoveOptions()
+
+        return true
+    }
+
     onInputChangeTriggered = (event) => {
         event.stopPropagation();
         this.hiddenTextTarget.value = this.inputTarget.value;
@@ -463,9 +485,7 @@ class AutoComplete extends Controller {
             this.fireChangeEvent(this.inputTarget.value, this.inputTarget.value, null);
         } else {
             if (this.inputTarget.value != "") {
-                let newValue = this.inputTarget.value;
-                let option = this._selectOptions.find(option => option.text == newValue && option.enabled != false);
-                this.value = option ? option.value : "";
+                this.commitExactTextMatch();
             } else {
                 this.clear();
             }
@@ -493,9 +513,7 @@ class AutoComplete extends Controller {
                 this.fireChangeEvent(this.inputTarget.value, this.inputTarget.value, null);
             } else {
                 if (this.inputTarget.value != "") {
-                    let newValue = this.inputTarget.value;
-                    let option = this._selectOptions.find(option => option.text == newValue && option.enabled != false);
-                    this.value = option ? option.value : "";
+                    this.commitExactTextMatch();
                 } else {
                     this.clear();
                 }
@@ -508,6 +526,7 @@ class AutoComplete extends Controller {
     commit(selected) {
         this.hiddenTextTarget.value = this.inputTarget.value;
         if (selected.getAttribute("aria-disabled") === "true") return
+        this.cancelPendingInputChange()
 
         if (selected instanceof HTMLAnchorElement) {
             selected.click()
@@ -557,6 +576,7 @@ class AutoComplete extends Controller {
     }
 
     clear() {
+        this.cancelPendingInputChange()
         this.inputTarget.value = "";
         if (this.hasHiddenTarget) this.hiddenTarget.value = "";
         if (this.hasHiddenTextTarget) this.hiddenTextTarget.value = "";
@@ -749,10 +769,20 @@ class AutoComplete extends Controller {
 const debounce = (fn, delay = 10) => {
     let timeoutId = null
 
-    return (...args) => {
+    const debounced = (...args) => {
         clearTimeout(timeoutId)
-        timeoutId = setTimeout(fn, delay)
+        timeoutId = setTimeout(() => {
+            timeoutId = null
+            fn(...args)
+        }, delay)
     }
+
+    debounced.cancel = () => {
+        clearTimeout(timeoutId)
+        timeoutId = null
+    }
+
+    return debounced
 }
 
 if (!window.Controllers) {

--- a/app/tests/js/controllers/auto-complete-controller.test.js
+++ b/app/tests/js/controllers/auto-complete-controller.test.js
@@ -962,10 +962,15 @@ describe('AutoCompleteController', () => {
         setupController({ allowOther: false });
         controller._selectOptions = [{ value: '1', text: 'Known Item' }];
         controller.inputTarget.value = 'Known Item';
+        const handler = jest.fn();
+        controller.element.addEventListener('autocomplete.change', handler);
 
         controller.onTabKeydown({});
 
         expect(controller.hiddenTarget.value).toBe('1');
+        expect(handler).toHaveBeenCalledWith(expect.objectContaining({
+            detail: expect.objectContaining({ value: '1', textValue: 'Known Item' })
+        }));
     });
 
     test('onTabKeydown with empty input calls clear', () => {
@@ -976,6 +981,41 @@ describe('AutoCompleteController', () => {
         controller.onTabKeydown({});
 
         expect(controller.clear).toHaveBeenCalled();
+    });
+
+    test('onTabKeydown cancels pending debounced input clearing for exact matches', () => {
+        jest.useFakeTimers();
+        try {
+            setupController({ allowOther: false, delay: 300 });
+            controller._selectOptions = [{ value: '1', text: 'Known Item' }];
+            controller.connect();
+            controller.inputTarget.value = 'Known Item';
+
+            controller.onInputChange();
+            controller.onTabKeydown({});
+            jest.advanceTimersByTime(300);
+
+            expect(controller.hiddenTarget.value).toBe('1');
+            expect(controller.hiddenTextTarget.value).toBe('Known Item');
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test('onInputBlur without allowOther commits exact text match and fires change event', () => {
+        setupController({ allowOther: false });
+        controller._selectOptions = [{ value: '1', text: 'Known Item' }];
+        controller.inputTarget.value = 'Known Item';
+        controller.state = 'open';
+        const handler = jest.fn();
+        controller.element.addEventListener('autocomplete.change', handler);
+
+        controller.onInputBlur();
+
+        expect(controller.hiddenTarget.value).toBe('1');
+        expect(handler).toHaveBeenCalledWith(expect.objectContaining({
+            detail: expect.objectContaining({ value: '1', textValue: 'Known Item' })
+        }));
     });
 
     // ==================== Disconnect ====================

--- a/app/tests/ui/bdd/@awards/steps.js
+++ b/app/tests/ui/bdd/@awards/steps.js
@@ -3,12 +3,11 @@ const { expect } = require('@playwright/test');
 
 const { Given, When, Then } = createBdd();
 
-async function chooseComboboxOption(page, inputSelector, text) {
+async function commitComboboxByTyping(page, inputSelector, hiddenSelector, text) {
     const input = page.locator(inputSelector);
     await input.fill(text);
-    const option = page.locator("[role='option']", { hasText: text }).first();
-    await option.waitFor({ state: 'visible', timeout: 5000 });
-    await option.click();
+    await input.press('Tab');
+    await expect(page.locator(hiddenSelector)).toHaveValue(/.+/);
 }
 
 When('I enter {string} as an unmatched recommendation recipient', async ({ page }, recipient) => {
@@ -43,16 +42,18 @@ When('I submit a public recommendation for the unmatched recipient {string}', as
     await recipientInput.press('Tab');
     await expect(page.locator('[data-awards-rec-add-target="branch"]')).toHaveJSProperty('hidden', false);
 
-    await chooseComboboxOption(page, '#branch_name-disp', 'Out of Kingdom');
-    await chooseComboboxOption(page, '#domain_name-disp', 'General');
-    await page.waitForResponse(resp =>
+    await commitComboboxByTyping(page, '#branch_name-disp', '[name="branch_id"]', 'Out of Kingdom');
+    const awardResponse = page.waitForResponse(resp =>
         resp.url().includes('/awards/awards/awards-by-domain/')
         && resp.status() === 200
     );
+    await commitComboboxByTyping(page, '#domain_name-disp', '[name="domain_id"]', 'General');
+    await awardResponse;
+    await expect(page.locator('#award_name-disp')).toBeEnabled();
 
     const firstAward = page.locator('#award_descriptions button[data-award-id]').first();
     const firstAwardText = (await firstAward.textContent()).trim();
-    await chooseComboboxOption(page, '#award_name-disp', firstAwardText);
+    await commitComboboxByTyping(page, '#award_name-disp', '[name="award_id"]', firstAwardText);
 
     await page.locator('#recommendation_reason').fill('Public submission regression coverage for a non-member recipient.');
     await page.getByRole('button', { name: /submit/i }).click();

--- a/app/webroot/mix-manifest.json
+++ b/app/webroot/mix-manifest.json
@@ -1,6 +1,6 @@
 {
-    "/js/controllers.js": "/js/controllers.js?id=202fce9ad62b363ed4d8f0bb3bd4f302",
-    "/js/controllers.js.map": "/js/controllers.js.map?id=39bb406237520ffe099afa630bc57f96",
+    "/js/controllers.js": "/js/controllers.js?id=38cfa6e45d27288e4a0f49b15db7f0d3",
+    "/js/controllers.js.map": "/js/controllers.js.map?id=9f473600b1a03ecc5228ebd206730553",
     "/js/index.js": "/js/index.js?id=05d7f1033862d7be58ed727b7d7c2cc7",
     "/js/index.js.map": "/js/index.js.map?id=ffe305d280ef46561da898234956c04b",
     "/js/manifest.js": "/js/manifest.js?id=a1879ee9d08c6841b38c934bfb04a4dc",


### PR DESCRIPTION
## Summary
- preserve exact-match combobox selections when users type and tab through the public awards recommendation form
- cancel stale debounced autocomplete clears that were wiping hidden IDs before submit
- cover the keyboard-only path in Jest and Playwright awards regressions

## Validation
- npm run development
- npx jest tests/js/controllers/auto-complete-controller.test.js tests/js/controllers/rec-add-controller.test.js tests/js/controllers/rec-edit-controller.test.js
- PLAYWRIGHT_BASE_URL=http://127.0.0.1:8080 npx playwright test tests/ui/gen/@awards/AwardRecommendations.feature.spec.js --grep "Submit recommendation marks unmatched recipients as not registered|Public submit recommendation succeeds for an unmatched recipient|Recommendations grid does not link unmatched recipients to member profiles"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-complete field behavior to properly recognize and commit exact text matches when users press Tab or click outside the field, preventing loss of valid selections.
  * Enhanced handling of pending input changes to ensure clean state during form interactions.

* **Tests**
  * Added comprehensive test coverage for exact-match selection and input state management in auto-complete workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->