### PR TITLE
fix(awards): add award level filter to recommendations grid and update related queries

### DIFF
--- a/app/plugins/Awards/src/KMP/GridColumns/RecommendationsGridColumns.php
+++ b/app/plugins/Awards/src/KMP/GridColumns/RecommendationsGridColumns.php
@@ -341,6 +341,23 @@ class RecommendationsGridColumns extends BaseGridColumns
                 'description' => 'Award being recommended',
             ],
 
+            'level_name' => [
+                'key' => 'level_name',
+                'label' => 'Award Level',
+                'type' => 'relation',
+                'sortable' => false,
+                'searchable' => false,
+                'filterable' => true,
+                'filterType' => 'dropdown',
+                'filterOptionsSource' => 'Awards.Levels',
+                'defaultVisible' => false,
+                'width' => '140px',
+                'alignment' => 'left',
+                'renderField' => 'award.level.name',
+                'queryField' => 'Levels.id',
+                'description' => 'Award precedence level',
+            ],
+
             'specialty' => [
                 'key' => 'specialty',
                 'label' => 'Specialty',
@@ -499,7 +516,7 @@ class RecommendationsGridColumns extends BaseGridColumns
 
             'branch_type' => [
                 'key' => 'branch_type',
-                'label' => 'Award Level',
+                'label' => 'Award Scope',
                 'type' => 'relation',
                 'sortable' => false,
                 'searchable' => false,
@@ -518,7 +535,7 @@ class RecommendationsGridColumns extends BaseGridColumns
                     ['value' => 'Principality', 'label' => 'Principality'],
                     ['value' => 'Local Group', 'label' => 'Local Group'],
                 ],
-                'description' => 'Branch type of the awarding entity (Kingdom, Principality, Barony)',
+                'description' => 'Scope of the awarding entity (Kingdom, Principality, Local Group)',
             ],
         ];
     }

--- a/app/plugins/Awards/src/Services/RecommendationQueryService.php
+++ b/app/plugins/Awards/src/Services/RecommendationQueryService.php
@@ -32,20 +32,24 @@ class RecommendationQueryService
     {
         $baseQuery = $recommendationsTable->find()
             ->innerJoinWith('Awards.AwardBranch')
+            ->innerJoinWith('Awards.Levels')
             ->contain([
                 'Requesters' => function ($q) {
                     return $q->select(['id', 'sca_name']);
                 },
                 'Members' => function ($q) {
-                    return $q->select(['id', 'sca_name', 'title', 'pronouns', 'pronunciation']);
+                    return $q->select(['id', 'sca_name', 'title', 'pronouns', 'pronunciation', 'additional_info']);
                 },
                 'Branches' => function ($q) {
                     return $q->select(['id', 'name', 'type']);
                 },
                 'Awards' => function ($q) {
-                    return $q->select(['id', 'abbreviation', 'branch_id']);
+                    return $q->select(['id', 'abbreviation', 'branch_id', 'level_id']);
                 },
                 'Awards.Domains' => function ($q) {
+                    return $q->select(['id', 'name']);
+                },
+                'Awards.Levels' => function ($q) {
                     return $q->select(['id', 'name']);
                 },
                 'Awards.AwardBranch' => function ($q) {
@@ -105,12 +109,20 @@ class RecommendationQueryService
     {
         $baseQuery = $recommendationsTable->find()
             ->where(['Recommendations.requester_id' => $memberId])
+            ->innerJoinWith('Awards.AwardBranch')
+            ->innerJoinWith('Awards.Levels')
             ->contain([
                 'Members' => function ($q) {
-                    return $q->select(['id', 'sca_name']);
+                    return $q->select(['id', 'sca_name', 'additional_info']);
                 },
                 'Awards' => function ($q) {
-                    return $q->select(['id', 'abbreviation']);
+                    return $q->select(['id', 'abbreviation', 'branch_id', 'level_id']);
+                },
+                'Awards.Levels' => function ($q) {
+                    return $q->select(['id', 'name']);
+                },
+                'Awards.AwardBranch' => function ($q) {
+                    return $q->select(['id', 'name', 'type']);
                 },
                 'Gatherings' => function ($q) {
                     return $q->select(['id', 'name', 'start_date', 'end_date']);
@@ -149,12 +161,20 @@ class RecommendationQueryService
     {
         $baseQuery = $recommendationsTable->find()
             ->where(['Recommendations.member_id' => $memberId])
+            ->innerJoinWith('Awards.AwardBranch')
+            ->innerJoinWith('Awards.Levels')
             ->contain([
                 'Requesters' => function ($q) {
                     return $q->select(['id', 'sca_name']);
                 },
                 'Awards' => function ($q) {
-                    return $q->select(['id', 'abbreviation']);
+                    return $q->select(['id', 'abbreviation', 'branch_id', 'level_id']);
+                },
+                'Awards.Levels' => function ($q) {
+                    return $q->select(['id', 'name']);
+                },
+                'Awards.AwardBranch' => function ($q) {
+                    return $q->select(['id', 'name', 'type']);
                 },
                 'Gatherings' => function ($q) {
                     return $q->select(['id', 'name', 'start_date', 'end_date']);
@@ -196,21 +216,29 @@ class RecommendationQueryService
     {
         $baseQuery = $recommendationsTable->find()
             ->where(['Recommendations.gathering_id' => $gatheringId])
+            ->innerJoinWith('Awards.AwardBranch')
+            ->innerJoinWith('Awards.Levels')
             ->contain([
                 'Requesters' => function ($q) {
                     return $q->select(['id', 'sca_name']);
                 },
                 'Members' => function ($q) {
-                    return $q->select(['id', 'sca_name', 'title', 'pronouns', 'pronunciation']);
+                    return $q->select(['id', 'sca_name', 'title', 'pronouns', 'pronunciation', 'additional_info']);
                 },
                 'Branches' => function ($q) {
                     return $q->select(['id', 'name', 'type']);
                 },
                 'Awards' => function ($q) {
-                    return $q->select(['id', 'abbreviation', 'branch_id']);
+                    return $q->select(['id', 'abbreviation', 'branch_id', 'level_id']);
                 },
                 'Awards.Domains' => function ($q) {
                     return $q->select(['id', 'name']);
+                },
+                'Awards.Levels' => function ($q) {
+                    return $q->select(['id', 'name']);
+                },
+                'Awards.AwardBranch' => function ($q) {
+                    return $q->select(['id', 'name', 'type']);
                 },
                 'Gatherings' => function ($q) {
                     return $q->select(['id', 'name', 'start_date', 'end_date']);

--- a/app/plugins/Awards/tests/TestCase/Controller/RecommendationsGridTest.php
+++ b/app/plugins/Awards/tests/TestCase/Controller/RecommendationsGridTest.php
@@ -1,0 +1,147 @@
+<?php
+declare(strict_types=1);
+
+namespace Awards\Test\TestCase\Controller;
+
+use App\Test\TestCase\Support\HttpIntegrationTestCase;
+use Awards\Model\Entity\Recommendation;
+
+class RecommendationsGridTest extends HttpIntegrationTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->enableCsrfToken();
+        $this->enableSecurityToken();
+        $this->authenticateAsSuperUser();
+    }
+
+    public function testGridDataIncludesAwardLevelFilterAndAppliesIt(): void
+    {
+        [$matchingAward, $otherAward] = $this->getAwardsWithDifferentLevels();
+
+        $matchingReason = 'award-level-filter-match-' . uniqid();
+        $otherReason = 'award-level-filter-other-' . uniqid();
+
+        $this->createRecommendation($matchingAward->id, $matchingReason);
+        $this->createRecommendation($otherAward->id, $otherReason);
+
+        $url = '/awards/recommendations/grid-data?' . http_build_query([
+            'view_id' => 'sys-recs-all',
+            'search' => 'award-level-filter-',
+            'filter' => [
+                'level_name' => (string)$matchingAward->level_id,
+            ],
+        ]);
+
+        $this->get($url);
+
+        $this->assertResponseOk();
+        $this->assertResponseContains('Award Level');
+        $this->assertResponseContains($matchingReason);
+        $this->assertResponseNotContains($otherReason);
+    }
+
+    public function testGridDataShowsOrderOfPrecedenceLink(): void
+    {
+        $appSettings = $this->getTableLocator()->get('AppSettings');
+        $members = $this->getTableLocator()->get('Members');
+        $awards = $this->getTableLocator()->get('Awards.Awards');
+
+        $appSettings->setAppSetting(
+            'Member.ExternalLink.Order of Precedence',
+            'https://op.example.test/people/id/{{additional_info->OrderOfPrecedence_Id}}',
+            'string',
+            false,
+        );
+
+        $member = $members->get(self::ADMIN_MEMBER_ID);
+        $member->additional_info = ['OrderOfPrecedence_Id' => '424242'];
+        $savedMember = $members->save($member);
+        $this->assertNotFalse($savedMember, 'Failed to save test member OP data');
+
+        $award = $awards->find()->select(['id'])->firstOrFail();
+        $reason = 'op-link-grid-test-' . uniqid();
+        $this->createRecommendation($award->id, $reason);
+
+        $url = '/awards/recommendations/grid-data?' . http_build_query([
+            'view_id' => 'sys-recs-all',
+            'search' => $reason,
+        ]);
+
+        $this->get($url);
+
+        $this->assertResponseOk();
+        $this->assertResponseContains('https://op.example.test/people/id/424242');
+    }
+
+    /**
+     * @return array{0: \Awards\Model\Entity\Award, 1: \Awards\Model\Entity\Award}
+     */
+    private function getAwardsWithDifferentLevels(): array
+    {
+        $awards = $this->getTableLocator()->get('Awards.Awards')
+            ->find()
+            ->select(['id', 'level_id'])
+            ->where(['Awards.deleted IS' => null])
+            ->orderByAsc('Awards.id')
+            ->all()
+            ->toList();
+
+        $firstAward = null;
+        $secondAward = null;
+
+        foreach ($awards as $award) {
+            if ($firstAward === null) {
+                $firstAward = $award;
+                continue;
+            }
+
+            if ($award->level_id !== $firstAward->level_id) {
+                $secondAward = $award;
+                break;
+            }
+        }
+
+        $this->assertNotNull($firstAward, 'Expected at least one seeded award');
+        $this->assertNotNull($secondAward, 'Expected seeded awards with different levels');
+
+        return [$firstAward, $secondAward];
+    }
+
+    private function createRecommendation(int $awardId, string $reason): Recommendation
+    {
+        $recommendations = $this->getTableLocator()->get('Awards.Recommendations');
+        $states = Recommendation::getStates();
+        $this->assertNotEmpty($states, 'Expected configured recommendation states');
+
+        $rankResult = $recommendations->find()
+            ->select(['max_rank' => $recommendations->find()->func()->max('stack_rank')])
+            ->disableHydration()
+            ->first();
+        $maxStackRank = (int)($rankResult['max_rank'] ?? 0);
+
+        $recommendation = $recommendations->newEntity([
+            'stack_rank' => $maxStackRank + 1,
+            'requester_id' => self::ADMIN_MEMBER_ID,
+            'member_id' => self::ADMIN_MEMBER_ID,
+            'branch_id' => self::KINGDOM_BRANCH_ID,
+            'award_id' => $awardId,
+            'state' => $states[0],
+            'requester_sca_name' => 'Admin von Admin',
+            'member_sca_name' => 'Admin von Admin',
+            'contact_email' => 'admin@amp.ansteorra.org',
+            'contact_number' => '555-555-0100',
+            'reason' => $reason,
+            'call_into_court' => 'Never',
+            'court_availability' => 'Any',
+            'created_by' => self::ADMIN_MEMBER_ID,
+            'modified_by' => self::ADMIN_MEMBER_ID,
+        ]);
+
+        $saved = $recommendations->save($recommendation);
+        $this->assertNotFalse($saved, 'Failed to save test recommendation');
+
+        return $saved;
+    }
+}


### PR DESCRIPTION
## Summary
- add an award level filter to the recommendations grid
- update recommendation queries so results respect the selected award level
- cover the new filter behavior in the recommendations grid test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added award level filtering capability to the recommendations grid, enabling users to filter by specific award levels
  * Order of Precedence member links now display correctly in grid search results

* **Improvements**
  * Renamed "Award Level" column to "Award Scope" for clarity
  * Updated column descriptions to better reflect award categorization terminology

<!-- end of auto-generated comment: release notes by coderabbit.ai -->