### PR TITLE
fix(awards): disable awards for new recommendations

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -53,5 +53,5 @@
 		"--add-host=host.docker.internal:host-gateway",
 		"--env=DISPLAY=host.docker.internal:0"
 	],
-	"postStartCommand": "bash .devcontainer/init_env/config_space.sh"
+	"postStartCommand": "bash .devcontainer/init_env/persist_home_state.sh && bash .devcontainer/init_env/config_space.sh"
 }

--- a/.devcontainer/init_env/persist_home_state.sh
+++ b/.devcontainer/init_env/persist_home_state.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -euo pipefail
+
+# Persist user auth and SSH material into the workspace so rebuilds can restore it.
+: "${REPO_PATH:?REPO_PATH must be set}"
+
+PERSIST_ROOT="$REPO_PATH/.container-home/vscode"
+
+mkdir -p "$PERSIST_ROOT"
+chmod 700 "$PERSIST_ROOT"
+
+persist_directory() {
+    local source_path="$1"
+    local persist_path="$2"
+    local mode="$3"
+
+    mkdir -p "$(dirname "$persist_path")"
+
+    if [ -L "$source_path" ]; then
+        if [ "$(readlink -f "$source_path")" = "$persist_path" ]; then
+            chmod "$mode" "$persist_path" 2>/dev/null || true
+            return
+        fi
+        rm -f "$source_path"
+    elif [ -d "$source_path" ]; then
+        mkdir -p "$persist_path"
+        if find "$source_path" -mindepth 1 -maxdepth 1 -print -quit >/dev/null 2>&1; then
+            cp -a "$source_path"/. "$persist_path"/
+        fi
+        rm -rf "$source_path"
+    fi
+
+    mkdir -p "$(dirname "$source_path")"
+    mkdir -p "$persist_path"
+    ln -s "$persist_path" "$source_path"
+    chmod "$mode" "$persist_path"
+}
+
+persist_file() {
+    local source_path="$1"
+    local persist_path="$2"
+    local mode="$3"
+
+    mkdir -p "$(dirname "$persist_path")"
+
+    if [ -L "$source_path" ]; then
+        if [ "$(readlink -f "$source_path")" = "$persist_path" ]; then
+            chmod "$mode" "$persist_path" 2>/dev/null || true
+            return
+        fi
+        rm -f "$source_path"
+    elif [ -f "$source_path" ]; then
+        cp -a "$source_path" "$persist_path"
+        rm -f "$source_path"
+    elif [ ! -f "$persist_path" ]; then
+        return
+    fi
+
+    mkdir -p "$(dirname "$source_path")"
+    ln -s "$persist_path" "$source_path"
+    chmod "$mode" "$persist_path"
+}
+
+persist_directory "$HOME/.ssh" "$PERSIST_ROOT/.ssh" 700
+find "$PERSIST_ROOT/.ssh" -type f -exec chmod 600 {} + 2>/dev/null || true
+
+persist_directory "$HOME/.config/gh" "$PERSIST_ROOT/.config/gh" 700
+find "$PERSIST_ROOT/.config/gh" -type f -exec chmod 600 {} + 2>/dev/null || true
+
+persist_file "$HOME/.copilot/config.json" "$PERSIST_ROOT/.copilot/config.json" 600

--- a/.devcontainer/init_env/persist_home_state.sh
+++ b/.devcontainer/init_env/persist_home_state.sh
@@ -24,9 +24,7 @@ persist_directory() {
         rm -f "$source_path"
     elif [ -d "$source_path" ]; then
         mkdir -p "$persist_path"
-        if find "$source_path" -mindepth 1 -maxdepth 1 -print -quit >/dev/null 2>&1; then
-            cp -a "$source_path"/. "$persist_path"/
-        fi
+        cp -an "$source_path"/. "$persist_path"/ 2>/dev/null || true
         rm -rf "$source_path"
     fi
 
@@ -50,7 +48,9 @@ persist_file() {
         fi
         rm -f "$source_path"
     elif [ -f "$source_path" ]; then
-        cp -a "$source_path" "$persist_path"
+        if [ ! -e "$persist_path" ]; then
+            cp -a "$source_path" "$persist_path"
+        fi
         rm -f "$source_path"
     elif [ ! -f "$persist_path" ]; then
         return

--- a/.dockerignore
+++ b/.dockerignore
@@ -18,6 +18,7 @@ app/.phpunit.cache
 
 # Dev containers
 .devcontainer
+.container-home
 
 # Documentation
 docs

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ prod_dump.sql
 /test-results/
 /.playwright-cli/
 .beads/
+.container-home/
 installer/kmp
 installers/bin
 installer/bin/

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -3632,6 +3632,7 @@
             "version": "2.5.6",
             "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
             "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -3671,6 +3672,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3691,6 +3693,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3711,6 +3714,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3731,6 +3735,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3751,6 +3756,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3771,6 +3777,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3791,6 +3798,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3811,6 +3819,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3831,6 +3840,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3851,6 +3861,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3871,6 +3882,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3891,6 +3903,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3911,6 +3924,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -9867,7 +9881,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -9896,7 +9910,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
@@ -12474,6 +12488,7 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
             "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+            "dev": true,
             "license": "MIT",
             "optional": true
         },

--- a/app/plugins/Awards/Assets/js/controllers/rec-edit-controller.js
+++ b/app/plugins/Awards/Assets/js/controllers/rec-edit-controller.js
@@ -25,6 +25,7 @@ class AwardsRecommendationEditForm extends Controller {
         "externalLinks",
         "domain",
         "award",
+        "currentAwardId",
         "reason",
         "gatherings",
         "specialty",
@@ -226,6 +227,9 @@ class AwardsRecommendationEditForm extends Controller {
     /** Fetch awards for domain and populate award selection with autocomplete. */
     populateAwardDescriptions(event) {
         let url = this.awardListUrlValue + "/" + event.target.value;
+        if (this.hasCurrentAwardIdTarget && this.currentAwardIdTarget.value) {
+            url += `?current_award_id=${encodeURIComponent(this.currentAwardIdTarget.value)}`;
+        }
         fetch(url, this.optionsForFetch())
             .then(response => response.json())
             .then(data => {

--- a/app/plugins/Awards/Assets/js/controllers/rec-quick-edit-controller.js
+++ b/app/plugins/Awards/Assets/js/controllers/rec-quick-edit-controller.js
@@ -19,6 +19,7 @@ class AwardsRecommendationQuickEditForm extends Controller {
     static targets = [
         "domain",
         "award",
+        "currentAwardId",
         "reason",
         "gatherings",
         "specialty",
@@ -136,6 +137,9 @@ class AwardsRecommendationQuickEditForm extends Controller {
     /** Fetch awards for domain and populate award selection with autocomplete. */
     populateAwardDescriptions(event) {
         let url = this.awardListUrlValue + "/" + event.target.value;
+        if (this.hasCurrentAwardIdTarget && this.currentAwardIdTarget.value) {
+            url += `?current_award_id=${encodeURIComponent(this.currentAwardIdTarget.value)}`;
+        }
         fetch(url, this.optionsForFetch())
             .then(response => response.json())
             .then(data => {

--- a/app/plugins/Awards/config/Migrations/20260404000000_AddIsActiveToAwards.php
+++ b/app/plugins/Awards/config/Migrations/20260404000000_AddIsActiveToAwards.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Migrations\BaseMigration;
+
+class AddIsActiveToAwards extends BaseMigration
+{
+    /**
+     * Add an activity flag so retired awards can be hidden from new recommendation selection.
+     */
+    public function up(): void
+    {
+        $table = $this->table('awards_awards');
+        $table
+            ->addColumn('is_active', 'boolean', [
+                'default' => true,
+                'null' => false,
+                'after' => 'branch_id',
+            ])
+            ->addIndex(['is_active'], [
+                'name' => 'idx_awards_awards_is_active',
+            ])
+            ->update();
+
+        $this->execute('UPDATE awards_awards SET is_active = 1');
+    }
+
+    /**
+     * Remove the activity flag from awards.
+     */
+    public function down(): void
+    {
+        $table = $this->table('awards_awards');
+        $table
+            ->removeIndexByName('idx_awards_awards_is_active')
+            ->removeColumn('is_active')
+            ->update();
+    }
+}

--- a/app/plugins/Awards/config/Migrations/20260404000000_AddIsActiveToAwards.php
+++ b/app/plugins/Awards/config/Migrations/20260404000000_AddIsActiveToAwards.php
@@ -23,7 +23,7 @@ class AddIsActiveToAwards extends BaseMigration
             ])
             ->update();
 
-        $this->execute('UPDATE awards_awards SET is_active = 1');
+        $this->execute('UPDATE awards_awards SET is_active = TRUE');
     }
 
     /**

--- a/app/plugins/Awards/src/Controller/AwardsController.php
+++ b/app/plugins/Awards/src/Controller/AwardsController.php
@@ -21,6 +21,23 @@ use Awards\Controller\AppController;
 class AwardsController extends AppController
 {
     use DataverseGridTrait;
+
+    /**
+     * Convert disabled checkbox input into the persisted active flag.
+     *
+     * @param array<string, mixed> $data Submitted award form data.
+     * @return array<string, mixed>
+     */
+    protected function normalizeAwardFormData(array $data): array
+    {
+        if (array_key_exists('is_disabled', $data)) {
+            $data['is_active'] = !$data['is_disabled'];
+            unset($data['is_disabled']);
+        }
+
+        return $data;
+    }
+
     /**
      * Initialize Awards Controller.
      * 
@@ -61,18 +78,7 @@ class AwardsController extends AppController
     public function gridData(\App\Services\CsvExportService $csvExportService)
     {
         // Build base query with domain, level, and branch info
-        $baseQuery = $this->Awards->find()
-            ->contain([
-                'Domains' => function ($q) {
-                    return $q->select(['id', 'name']);
-                },
-                'Levels' => function ($q) {
-                    return $q->select(['id', 'name']);
-                },
-                'Branches' => function ($q) {
-                    return $q->select(['id', 'name']);
-                }
-            ]);
+        $baseQuery = $this->buildAwardsGridBaseQuery();
 
         // Use unified trait for grid processing
         $result = $this->processDataverseGrid([
@@ -132,6 +138,114 @@ class AwardsController extends AppController
             $this->viewBuilder()->setTemplatePath('element');
             $this->viewBuilder()->setTemplate('dv_grid_content');
         }
+    }
+
+    /**
+     * Provide award grid data scoped to a gathering activity.
+     *
+     * Uses the shared awards grid columns and an activity-specific remove row action.
+     *
+     * @param int|null $activityId Gathering activity identifier.
+     * @return \Cake\Http\Response|null|void
+     */
+    public function activityAwardsGridData(?int $activityId = null)
+    {
+        if ($activityId === null) {
+            throw new \Cake\Http\Exception\BadRequestException(__('Activity ID is required.'));
+        }
+
+        $gatheringActivity = $this->fetchTable('GatheringActivities')->get($activityId);
+        $this->Authorization->authorize($gatheringActivity, 'view');
+
+        $canEdit = (bool)$this->request->getAttribute('identity')?->can('edit', $gatheringActivity);
+
+        $baseQuery = $this->buildAwardsGridBaseQuery()
+            ->matching('GatheringActivities', function ($q) use ($activityId) {
+                return $q->where(['GatheringActivities.id' => $activityId]);
+            })
+            ->distinct([$this->Awards->aliasField('id')]);
+
+        $result = $this->processDataverseGrid([
+            'gridKey' => 'Awards.Awards.activity.' . $activityId,
+            'gridColumnsClass' => \Awards\KMP\GridColumns\AwardsGridColumns::class,
+            'baseQuery' => $baseQuery,
+            'tableName' => 'Awards',
+            'defaultSort' => ['Awards.name' => 'asc'],
+            'defaultPageSize' => 25,
+            'showAllTab' => false,
+            'canAddViews' => false,
+            'canFilter' => true,
+            'canExportCsv' => false,
+        ]);
+
+        $this->set([
+            'awards' => $result['data'],
+            'data' => $result['data'],
+            'rowActions' => $canEdit ? \Awards\KMP\GridColumns\AwardsGridColumns::getActivityRowActions($activityId) : [],
+            'gridState' => $result['gridState'],
+            'columns' => $result['columnsMetadata'],
+            'visibleColumns' => $result['visibleColumns'],
+            'searchableColumns' => \Awards\KMP\GridColumns\AwardsGridColumns::getSearchableColumns(),
+            'dropdownFilterColumns' => $result['dropdownFilterColumns'],
+            'filterOptions' => $result['filterOptions'],
+            'currentFilters' => $result['currentFilters'],
+            'currentSearch' => $result['currentSearch'],
+            'currentView' => $result['currentView'],
+            'availableViews' => $result['availableViews'],
+            'gridKey' => $result['gridKey'],
+            'currentSort' => $result['currentSort'],
+            'currentMember' => $result['currentMember'],
+        ]);
+
+        $turboFrame = $this->request->getHeaderLine('Turbo-Frame');
+        $frameId = 'activity-awards-grid-' . $activityId;
+        $dataUrl = \Cake\Routing\Router::url([
+            'plugin' => 'Awards',
+            'controller' => 'Awards',
+            'action' => 'activity-awards-grid-data',
+            $activityId,
+        ]);
+        $tableDataUrl = $dataUrl;
+        $queryParams = $this->request->getQueryParams();
+        if (!empty($queryParams)) {
+            $tableDataUrl .= '?' . http_build_query($queryParams);
+        }
+
+        $this->viewBuilder()->setPlugin(null);
+        $this->viewBuilder()->disableAutoLayout();
+        $this->viewBuilder()->setTemplatePath('element');
+
+        if ($turboFrame === $frameId . '-table') {
+            $this->set('tableFrameId', $frameId . '-table');
+            $this->viewBuilder()->setTemplate('dv_grid_table');
+            return;
+        }
+
+        $this->set('frameId', $frameId);
+        $this->set('dataUrl', $dataUrl);
+        $this->set('tableDataUrl', $tableDataUrl);
+        $this->viewBuilder()->setTemplate('dv_grid_content');
+    }
+
+    /**
+     * Build the base awards query used by dataverse grids.
+     *
+     * @return \Cake\ORM\Query\SelectQuery
+     */
+    protected function buildAwardsGridBaseQuery(): \Cake\ORM\Query\SelectQuery
+    {
+        return $this->Awards->find()
+            ->contain([
+                'Domains' => function ($q) {
+                    return $q->select(['id', 'name']);
+                },
+                'Levels' => function ($q) {
+                    return $q->select(['id', 'name']);
+                },
+                'Branches' => function ($q) {
+                    return $q->select(['id', 'name']);
+                },
+            ]);
     }
 
     /**
@@ -205,8 +319,9 @@ class AwardsController extends AppController
     public function add()
     {
         $award = $this->Awards->newEmptyEntity();
+        $award->is_active = true;
         if ($this->request->is('post')) {
-            $award = $this->Awards->patchEntity($award, $this->request->getData());
+            $award = $this->Awards->patchEntity($award, $this->normalizeAwardFormData($this->request->getData()));
             if ($this->Awards->save($award)) {
                 $this->Flash->success(__('The award has been saved.'));
 
@@ -241,7 +356,7 @@ class AwardsController extends AppController
         $this->Authorization->authorize($award);
 
         if ($this->request->is(['patch', 'post', 'put'])) {
-            $award = $this->Awards->patchEntity($award, $this->request->getData());
+            $award = $this->Awards->patchEntity($award, $this->normalizeAwardFormData($this->request->getData()));
             $specialties = json_decode($this->request->getData('specialties'), true);
             $award->specialties = $specialties;
             if ($this->Awards->save($award)) {
@@ -303,8 +418,11 @@ class AwardsController extends AppController
     public function awardsByDomain($domainId = null)
     {
         $this->Authorization->skipAuthorization();
-        $awards = $this->Awards->find()
-            ->where(['domain_id' => $domainId])
+        $currentAwardId = $this->request->getQuery('current_award_id');
+        $awards = $this->Awards->find('selectable', [
+                'domain_id' => $domainId,
+                'current_award_id' => $currentAwardId,
+            ])
             ->contain([
                 'Domains' => function ($q) {
                     return $q->select(['id', 'name']);
@@ -322,6 +440,31 @@ class AwardsController extends AppController
             ->withType("application/json")
             ->withStringBody(json_encode($awards));
         return $this->response;
+    }
+
+    /**
+     * Toggle whether an award can be selected for new recommendations.
+     *
+     * @param string|null $id Award identifier.
+     * @return \Cake\Http\Response|null
+     */
+    public function toggleActive(?string $id = null)
+    {
+        $this->request->allowMethod(['post']);
+
+        $award = $this->Awards->get($id);
+        $this->Authorization->authorize($award, 'edit');
+
+        $award->is_active = !$award->is_active;
+
+        if ($this->Awards->save($award)) {
+            $status = $award->is_active ? 'activated' : 'deactivated';
+            $this->Flash->success(__('The award has been {0}.', $status));
+        } else {
+            $this->Flash->error(__('The award status could not be changed. Please, try again.'));
+        }
+
+        return $this->redirect(['action' => 'view', $award->id]);
     }
 
     /**

--- a/app/plugins/Awards/src/Controller/RecommendationsController.php
+++ b/app/plugins/Awards/src/Controller/RecommendationsController.php
@@ -1151,7 +1151,10 @@ class RecommendationsController extends AppController
                 ->orderBy(['name' => 'ASC'])
                 ->toArray();
 
-            $awards = $this->Recommendations->Awards->find('list', limit: 200)->all();
+            $awards = $this->Recommendations->Awards
+                ->find('active')
+                ->find('list', limit: 200)
+                ->all();
             $gatherings = [];
 
             $this->set(compact('recommendation', 'branches', 'awards', 'gatherings', 'awardsDomains', 'awardsLevels'));
@@ -1291,7 +1294,10 @@ class RecommendationsController extends AppController
             ->orderBy(['name' => 'ASC'])
             ->toArray();
 
-        $awards = $this->Recommendations->Awards->find('list', limit: 200)->all();
+        $awards = $this->Recommendations->Awards
+            ->find('active')
+            ->find('list', limit: 200)
+            ->all();
         $gatherings = [];
 
         $this->set(compact(

--- a/app/plugins/Awards/src/KMP/GridColumns/AwardsGridColumns.php
+++ b/app/plugins/Awards/src/KMP/GridColumns/AwardsGridColumns.php
@@ -13,6 +13,34 @@ use App\KMP\GridColumns\BaseGridColumns;
 class AwardsGridColumns extends BaseGridColumns
 {
     /**
+     * Get row action configurations for awards shown in a gathering activity context.
+     *
+     * @param int $activityId Gathering activity identifier.
+     * @return array<string, array<string, mixed>>
+     */
+    public static function getActivityRowActions(int $activityId): array
+    {
+        return [
+            'removeActivity' => [
+                'key' => 'removeActivity',
+                'type' => 'postLink',
+                'label' => '',
+                'icon' => 'bi-x-circle-fill',
+                'class' => 'btn btn-sm btn-danger',
+                'url' => [
+                    'plugin' => 'Awards',
+                    'controller' => 'Awards',
+                    'action' => 'remove-activity',
+                    'idField' => 'id',
+                    'extraArgs' => [$activityId],
+                ],
+                'confirmMessage' => 'Remove "{{name}}" from this activity?',
+                'turbo' => true,
+            ],
+        ];
+    }
+
+    /**
      * Get column metadata for the awards grid
      *
      * @return array<string, array<string, mixed>>
@@ -89,6 +117,23 @@ class AwardsGridColumns extends BaseGridColumns
                 'renderField' => 'branch.name',
                 'width' => '150px',
                 'alignment' => 'left',
+            ],
+            'disabled' => [
+                'key' => 'disabled',
+                'label' => __('Disabled'),
+                'type' => 'boolean',
+                'sortable' => true,
+                'filterable' => true,
+                'filterType' => 'dropdown',
+                'queryField' => 'Awards.is_active',
+                'renderField' => 'disabled',
+                'defaultVisible' => true,
+                'width' => '100px',
+                'alignment' => 'center',
+                'filterOptions' => [
+                    ['value' => '0', 'label' => 'Yes'],
+                    ['value' => '1', 'label' => 'No'],
+                ],
             ],
             'description' => [
                 'key' => 'description',

--- a/app/plugins/Awards/src/Model/Entity/Award.php
+++ b/app/plugins/Awards/src/Model/Entity/Award.php
@@ -104,7 +104,7 @@ class Award extends BaseEntity
      */
     protected function _getDisabled(): bool
     {
-        return !$this->is_active;
+        return !((bool)($this->is_active ?? true));
     }
 
     /**
@@ -114,6 +114,6 @@ class Award extends BaseEntity
      */
     protected function _getDisabledLabel(): string
     {
-        return $this->disabled ? 'Yes' : 'No';
+        return $this->disabled ? (string)__('Yes') : (string)__('No');
     }
 }

--- a/app/plugins/Awards/src/Model/Entity/Award.php
+++ b/app/plugins/Awards/src/Model/Entity/Award.php
@@ -23,6 +23,9 @@ use App\Model\Entity\BaseEntity;
  * @property int $domain_id
  * @property int $level_id
  * @property int $branch_id
+ * @property bool $is_active
+ * @property bool $disabled
+ * @property string $disabled_label
  * @property \Cake\I18n\DateTime|null $open_date
  * @property \Cake\I18n\DateTime|null $close_date
  * @property \Cake\I18n\DateTime|null $modified
@@ -52,6 +55,7 @@ class Award extends BaseEntity
         'domain_id' => true,
         'level_id' => true,
         'branch_id' => true,
+        'is_active' => true,
         'modified' => true,
         'created' => true,
         'created_by' => true,
@@ -91,5 +95,25 @@ class Award extends BaseEntity
     protected function _getBranchName(): ?string
     {
         return $this->branch?->name ?? null;
+    }
+
+    /**
+     * Get disabled status for grid and form display.
+     *
+     * @return bool
+     */
+    protected function _getDisabled(): bool
+    {
+        return !$this->is_active;
+    }
+
+    /**
+     * Get disabled status label for grid display.
+     *
+     * @return string
+     */
+    protected function _getDisabledLabel(): string
+    {
+        return $this->disabled ? 'Yes' : 'No';
     }
 }

--- a/app/plugins/Awards/src/Model/Table/AwardsTable.php
+++ b/app/plugins/Awards/src/Model/Table/AwardsTable.php
@@ -154,6 +154,10 @@ class AwardsTable extends BaseTable
             ->notEmptyString('branch_id');
 
         $validator
+            ->boolean('is_active')
+            ->notEmptyString('is_active');
+
+        $validator
             ->integer('created_by')
             ->allowEmptyString('created_by');
 
@@ -182,6 +186,45 @@ class AwardsTable extends BaseTable
         $rules->add($rules->existsIn(['branch_id'], 'Branches'), ['errorField' => 'branch_id']);
 
         return $rules;
+    }
+
+    /**
+     * Restrict results to active awards.
+     *
+     * @param \Cake\ORM\Query\SelectQuery $query Query to filter
+     * @return \Cake\ORM\Query\SelectQuery
+     */
+    public function findActive(SelectQuery $query): SelectQuery
+    {
+        return $query->where([$this->aliasField('is_active') => true]);
+    }
+
+    /**
+     * Restrict recommendation award selection to active awards, while optionally preserving the currently selected award.
+     *
+     * @param \Cake\ORM\Query\SelectQuery $query Query to filter
+     * @param array<string, mixed> $options Finder options
+     * @return \Cake\ORM\Query\SelectQuery
+     */
+    public function findSelectable(SelectQuery $query, array $options): SelectQuery
+    {
+        $domainId = $options['domain_id'] ?? null;
+        $currentAwardId = $options['current_award_id'] ?? null;
+
+        if ($domainId !== null && $domainId !== '') {
+            $query->where([$this->aliasField('domain_id') => $domainId]);
+        }
+
+        if ($currentAwardId !== null && $currentAwardId !== '') {
+            return $query->where(function ($exp) use ($currentAwardId) {
+                return $exp->or([
+                    $this->aliasField('is_active') => true,
+                    $this->aliasField('id') => (int)$currentAwardId,
+                ]);
+            });
+        }
+
+        return $this->findActive($query);
     }
 
     /**

--- a/app/plugins/Awards/src/Model/Table/RecommendationsTable.php
+++ b/app/plugins/Awards/src/Model/Table/RecommendationsTable.php
@@ -222,8 +222,45 @@ class RecommendationsTable extends BaseTable
         $rules->add($rules->existsIn(['member_id'], 'Members'), ['errorField' => 'member_id']);
         $rules->add($rules->existsIn(['branch_id'], 'Branches'), ['errorField' => 'branch_id']);
         $rules->add($rules->existsIn(['award_id'], 'Awards'), ['errorField' => 'award_id']);
+        $rules->add(
+            fn(EntityInterface $entity) => $this->isAwardSelectableForRecommendation($entity),
+            'awardSelection',
+            [
+                'errorField' => 'award_id',
+                'message' => 'This award is inactive and can no longer be selected for new recommendations.',
+            ],
+        );
 
         return $rules;
+    }
+
+    /**
+     * Allow inactive awards only when an existing recommendation keeps its current award.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity Recommendation entity being saved
+     * @return bool
+     */
+    protected function isAwardSelectableForRecommendation(EntityInterface $entity): bool
+    {
+        if (!$entity instanceof Recommendation || $entity->award_id === null) {
+            return true;
+        }
+
+        if (!$entity->isNew() && !$entity->isDirty('award_id')) {
+            return true;
+        }
+
+        $award = $this->Awards->find()
+            ->select(['id', 'is_active'])
+            ->where(['Awards.id' => $entity->award_id])
+            ->disableHydration()
+            ->first();
+
+        if ($award === null) {
+            return true;
+        }
+
+        return (bool)$award['is_active'];
     }
 
     /**

--- a/app/plugins/Awards/src/Services/RecommendationFormService.php
+++ b/app/plugins/Awards/src/Services/RecommendationFormService.php
@@ -87,9 +87,12 @@ class RecommendationFormService
 
         $branches = $this->buildBranchesList($awardsTable);
 
-        $awards = $awardsTable->find('all', limit: 200)
+        $awards = $awardsTable->find('selectable', [
+                'domain_id' => $recommendation->domain_id,
+                'current_award_id' => $recommendation->award_id,
+            ])
             ->select(['id', 'name', 'specialties'])
-            ->where(['domain_id' => $recommendation->domain_id])
+            ->limit(200)
             ->all();
 
         // Get filtered gatherings for this award

--- a/app/plugins/Awards/src/View/Cell/ActivityAwardsCell.php
+++ b/app/plugins/Awards/src/View/Cell/ActivityAwardsCell.php
@@ -22,11 +22,10 @@ class ActivityAwardsCell extends Cell
     /**
      * Prepare and expose awards data related to a gathering activity for the view.
      *
-     * Loads the gathering activity, enforces view/edit permissions, fetches awards
-     * associated with the activity (including domain, level, and branch relationships),
-     * and computes a list of awards not yet associated for addition when the user can edit.
+     * Loads the gathering activity, enforces view/edit permissions, and computes
+     * a list of awards not yet associated for addition when the user can edit.
      *
-     * Exposes template variables: `gatheringActivity`, `awards`, `canEdit`, and `availableAwards`.
+     * Exposes template variables: `gatheringActivity`, `canEdit`, and `availableAwards`.
      *
      * @param int $activityId The ID of the gathering activity.
      */
@@ -46,20 +45,16 @@ class ActivityAwardsCell extends Cell
         // Check if user can edit (for add/remove functionality)
         $canEdit = $user->can('edit', $gatheringActivity);
 
-        // Load awards that are associated with this gathering activity
-        // We query from the Awards side since that's where the relationship exists
         $awardsTable = TableRegistry::getTableLocator()->get('Awards.Awards');
-        $awards = $awardsTable->find()
-            ->matching('GatheringActivities', function ($q) use ($activityId) {
-                return $q->where(['GatheringActivities.id' => $activityId]);
-            })
-            ->contain(['Domains', 'Levels', 'Branches'])
-            ->all();
-
-        // Get existing award IDs for filtering available awards
-        $existingAwardIds = array_map(function ($award) {
-            return $award->id;
-        }, $awards->toArray());
+        $existingAwardIds = TableRegistry::getTableLocator()
+            ->get('Awards.AwardGatheringActivities')
+            ->find()
+            ->select(['award_id'])
+            ->where(['gathering_activity_id' => $activityId])
+            ->disableHydration()
+            ->all()
+            ->extract('award_id')
+            ->toList();
 
         // Get available awards (not already associated)
         $availableAwards = [];
@@ -75,6 +70,6 @@ class ActivityAwardsCell extends Cell
                 ->toArray();
         }
 
-        $this->set(compact('gatheringActivity', 'awards', 'canEdit', 'availableAwards'));
+        $this->set(compact('gatheringActivity', 'canEdit', 'availableAwards'));
     }
 }

--- a/app/plugins/Awards/templates/Awards/add.php
+++ b/app/plugins/Awards/templates/Awards/add.php
@@ -41,6 +41,11 @@ $this->KMP->endBlock(); ?>
         echo $this->Form->control('insignia');
         echo $this->Form->control('badge');
         echo $this->Form->control('charter');
+        echo $this->Form->control('is_disabled', [
+            'type' => 'checkbox',
+            'label' => __('Disabled'),
+            'checked' => !$award->is_active,
+        ]);
         echo $this->Form->control('domain_id', ['options' => $awardsDomains]);
         echo $this->Form->control('level_id', ['options' => $awardsLevels]);
         echo $this->Form->control('branch_id', ['options' => $branches]);

--- a/app/plugins/Awards/templates/Awards/view.php
+++ b/app/plugins/Awards/templates/Awards/view.php
@@ -18,7 +18,7 @@ echo $this->KMP->startBlock("pageTitle") ?>
 <?php $this->KMP->endBlock() ?>
 <?= $this->KMP->startBlock("recordActions") ?>
 <?php if ($user->checkCan("edit", $award)) : ?>
-    <button type="button" class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#editModal">Edit</button>
+<button type="button" class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#editModal">Edit</button>
 <?php endif; ?>
 <?php if (empty($award->recommendations) && $user->checkCan("delete", $award)) {
     echo $this->Form->postLink(
@@ -41,18 +41,18 @@ echo $this->KMP->startBlock("pageTitle") ?>
     <td> <?= h($award->abbreviation) ?></td>
 </tr>
 <?php if ($award->specialties) : ?>
-    <tr>
-        <th scope="row"><?= __('Specialties') ?></th>
-        <td>
-            <ul>
-                <?php
+<tr>
+    <th scope="row"><?= __('Specialties') ?></th>
+    <td>
+        <ul>
+            <?php
                 // parse the JSON to get the list of specialties
                 foreach ($award->specialties as $specialty) : ?>
-                    <li><?= h($specialty) ?></li>
-                <?php endforeach; ?>
-            </ul>
-        </td>
-    </tr>
+            <li><?= h($specialty) ?></li>
+            <?php endforeach; ?>
+        </ul>
+    </td>
+</tr>
 <?php endif; ?>
 <tr>
     <th scope="row"><?= __('Description') ?></th>
@@ -101,6 +101,16 @@ echo $this->KMP->startBlock("pageTitle") ?>
     <td><?= $award->hasValue('branch') ? $this->Html->link($award->branch->name, ['plugin' => null, 'controller' => 'Branches', 'action' => 'view', $award->branch->public_id]) : '' ?>
     </td>
 </tr>
+<tr>
+    <th scope="row"><?= __('Disabled') ?></th>
+    <td>
+        <?php if ($award->disabled): ?>
+        <span class="badge bg-danger"><?= __('Yes') ?></span>
+        <?php else: ?>
+        <span class="badge bg-success"><?= __('No') ?></span>
+        <?php endif; ?>
+    </td>
+</tr>
 <?php $this->KMP->endBlock() ?>
 <?php $this->KMP->startBlock("tabButtons") ?>
 <!-- Award Activities tab with ordering
@@ -119,34 +129,34 @@ echo $this->KMP->startBlock("pageTitle") ?>
 
     <div class="d-flex justify-content-between align-items-center mb-3">
         <?php if ($user->checkCan('edit', $award)) : ?>
-            <button type="button" class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#addActivityModal">
-                <i class="bi bi-plus-circle"></i> <?= __('Add Activity') ?>
-            </button>
+        <button type="button" class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#addActivityModal">
+            <i class="bi bi-plus-circle"></i> <?= __('Add Activity') ?>
+        </button>
         <?php endif; ?>
     </div>
 
     <?php if (!empty($award->gathering_activities)) : ?>
-        <div class="table-responsive">
-            <table class="table table-striped">
-                <thead>
-                    <tr>
-                        <th><?= __('Activity') ?></th>
-                        <th><?= __('Description') ?></th>
-                        <th class="actions"></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php foreach ($award->gathering_activities as $activity) : ?>
-                        <tr>
-                            <td>
-                                <?= h($activity->name) ?>
-                            </td>
-                            <td>
-                                <?= h($activity->description) ?>
-                            </td>
-                            <td class="actions text-end text-nowrap">
-                                <?php if ($user->checkCan('edit', $award)) : ?>
-                                    <?= $this->Form->postLink(
+    <div class="table-responsive">
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th><?= __('Activity') ?></th>
+                    <th><?= __('Description') ?></th>
+                    <th class="actions"></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($award->gathering_activities as $activity) : ?>
+                <tr>
+                    <td>
+                        <?= h($activity->name) ?>
+                    </td>
+                    <td>
+                        <?= h($activity->description) ?>
+                    </td>
+                    <td class="actions text-end text-nowrap">
+                        <?php if ($user->checkCan('edit', $award)) : ?>
+                        <?= $this->Form->postLink(
                                         '<i class="bi bi-x-circle-fill"></i>',
                                         ['action' => 'remove-activity', $award->id, $activity->id],
                                         [
@@ -156,21 +166,21 @@ echo $this->KMP->startBlock("pageTitle") ?>
                                             'class' => 'btn btn-sm btn-danger',
                                         ],
                                     ) ?>
-                                <?php endif; ?>
-                            </td>
-                        </tr>
-                    <?php endforeach; ?>
-                </tbody>
-            </table>
-        </div>
+                        <?php endif; ?>
+                    </td>
+                </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
     <?php else : ?>
-        <div class="alert alert-secondary">
-            <i class="bi bi-info-circle"></i>
-            <?= __('No activities have been added to this award yet.') ?>
-            <?php if ($user->checkCan('edit', $award)) : ?>
-                <?= __('Click "Add Activity" above to get started.') ?>
-            <?php endif; ?>
-        </div>
+    <div class="alert alert-secondary">
+        <i class="bi bi-info-circle"></i>
+        <?= __('No activities have been added to this award yet.') ?>
+        <?php if ($user->checkCan('edit', $award)) : ?>
+        <?= __('Click "Add Activity" above to get started.') ?>
+        <?php endif; ?>
+    </div>
     <?php endif; ?>
 </div>
 <?php $this->KMP->endBlock() ?>
@@ -212,6 +222,11 @@ echo $this->Modal->create("Edit Award", [
     echo $this->Form->control('insignia');
     echo $this->Form->control('badge');
     echo $this->Form->control('charter');
+    echo $this->Form->control('is_disabled', [
+        'type' => 'checkbox',
+        'label' => __('Disabled'),
+        'checked' => $award->disabled,
+    ]);
     echo $this->Form->control('domain_id', ['options' => $awardsDomains]);
     echo $this->Form->control('level_id', ['options' => $awardsLevels]);
     echo $this->Form->control('branch_id', ['options' => $branches]);
@@ -245,19 +260,19 @@ if ($user->checkCan('edit', $award)) {
         'close' => true,
     ]);
 ?>
-    <div class="mb-3">
-        <label for="gathering_activity_id" class="form-label"><?= __('Select Activity') ?></label>
-        <?= $this->Form->control('gathering_activity_id', [
+<div class="mb-3">
+    <label for="gathering_activity_id" class="form-label"><?= __('Select Activity') ?></label>
+    <?= $this->Form->control('gathering_activity_id', [
             'options' => $availableActivities,
             'empty' => __('-- Select an activity --'),
             'class' => 'form-select',
             'label' => false,
             'required' => true,
         ]) ?>
-        <div class="form-text">
-            <?= __('Select a gathering activity that this award can be given out during.') ?>
-        </div>
+    <div class="form-text">
+        <?= __('Select a gathering activity that this award can be given out during.') ?>
     </div>
+</div>
 <?php
     echo $this->Modal->end([
         $this->Form->button(__('Add Activity'), [

--- a/app/plugins/Awards/templates/cell/ActivityAwards/display.php
+++ b/app/plugins/Awards/templates/cell/ActivityAwards/display.php
@@ -4,16 +4,15 @@
  * Activity Awards Cell Template
  * 
  * Displays awards that can be given out during a specific gathering activity.
- * Shows a list of associated awards with add/remove functionality for authorized users.
+ * Uses the shared awards dataverse grid with an activity-specific remove action.
  * 
  * @var \App\View\AppView $this
  * @var \App\Model\Entity\GatheringActivity $gatheringActivity
- * @var \Cake\ORM\ResultSet|\Awards\Model\Entity\Award[] $awards
  * @var bool $canEdit
  * @var array $availableAwards
  */
 
-$user = $this->request->getAttribute('identity');
+$gridFrameId = 'activity-awards-grid-' . $gatheringActivity->id;
 ?>
 
 <turbo-frame id="activity-awards-<?= $gatheringActivity->id ?>">
@@ -26,65 +25,17 @@ $user = $this->request->getAttribute('identity');
             <?php endif; ?>
         </div>
 
-        <?php if (!empty($awards) && $awards->count() > 0) : ?>
-            <div class="table-responsive">
-                <table class="table table-striped">
-                    <thead>
-                        <tr>
-                            <th><?= __('Award') ?></th>
-                            <th><?= __('Domain') ?></th>
-                            <th><?= __('Level') ?></th>
-                            <th><?= __('Branch') ?></th>
-                            <th class="actions"></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <?php foreach ($awards as $award) : ?>
-                            <tr>
-                                <td>
-                                    <?= h($award->name) ?>
-                                    <?php if ($award->abbreviation) : ?>
-                                        <small class="text-muted">(<?= h($award->abbreviation) ?>)</small>
-                                    <?php endif; ?>
-                                </td>
-                                <td>
-                                    <?= $award->has('domain') ? h($award->domain->name) : '' ?>
-                                </td>
-                                <td>
-                                    <?= $award->has('level') ? h($award->level->name) : '' ?>
-                                </td>
-                                <td>
-                                    <?= $award->has('branch') ? h($award->branch->name) : '' ?>
-                                </td>
-                                <td class="actions text-end text-nowrap">
-                                    <?php if ($canEdit) : ?>
-                                        <?= $this->Form->postLink(
-                                            '<i class="bi bi-x-circle-fill"></i>',
-                                            ['plugin' => 'Awards', 'controller' => 'Awards', 'action' => 'remove-activity', $award->id, $gatheringActivity->id],
-                                            [
-                                                'confirm' => __('Remove "{0}" from this activity?', $award->name),
-                                                'escape' => false,
-                                                'title' => __('Remove'),
-                                                'class' => 'btn btn-sm btn-danger',
-                                                'data-turbo' => 'true',
-                                            ],
-                                        ) ?>
-                                    <?php endif; ?>
-                                </td>
-                            </tr>
-                        <?php endforeach; ?>
-                    </tbody>
-                </table>
-            </div>
-        <?php else : ?>
-            <div class="alert alert-secondary">
-                <i class="bi bi-info-circle"></i>
-                <?= __('No awards have been associated with this activity yet.') ?>
-                <?php if ($canEdit && !empty($availableAwards)) : ?>
-                    <?= __('Click "Add Award" above to get started.') ?>
-                <?php endif; ?>
-            </div>
-        <?php endif; ?>
+        <?= $this->element('dv_grid', [
+            'gridKey' => 'Awards.Awards.activity.' . $gatheringActivity->id,
+            'frameId' => $gridFrameId,
+            'dataUrl' => $this->Url->build([
+                'plugin' => 'Awards',
+                'controller' => 'Awards',
+                'action' => 'activity-awards-grid-data',
+                $gatheringActivity->id,
+            ]),
+            'compactMode' => true,
+        ]) ?>
     </div>
 </turbo-frame>
 

--- a/app/plugins/Awards/tests/TestCase/Controller/AwardsControllerTest.php
+++ b/app/plugins/Awards/tests/TestCase/Controller/AwardsControllerTest.php
@@ -1,0 +1,119 @@
+<?php
+declare(strict_types=1);
+
+namespace Awards\Test\TestCase\Controller;
+
+use App\Test\TestCase\Support\HttpIntegrationTestCase;
+
+class AwardsControllerTest extends HttpIntegrationTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->enableCsrfToken();
+        $this->enableSecurityToken();
+        $this->authenticateAsSuperUser();
+    }
+
+    public function testEditCanDisableAward(): void
+    {
+        $awards = $this->getTableLocator()->get('Awards.Awards');
+        $award = $awards->saveOrFail($awards->newEntity([
+            'name' => 'Edit Disable Award ' . uniqid(),
+            'abbreviation' => 'EDA-' . uniqid(),
+            'domain_id' => 2,
+            'level_id' => 1,
+            'branch_id' => 27,
+            'is_active' => true,
+        ]));
+
+        $this->post('/awards/awards/edit/' . $award->id, [
+            'name' => $award->name,
+            'abbreviation' => $award->abbreviation,
+            'specialties' => '[]',
+            'description' => '',
+            'insignia' => '',
+            'badge' => '',
+            'charter' => '',
+            'domain_id' => $award->domain_id,
+            'level_id' => $award->level_id,
+            'branch_id' => $award->branch_id,
+            'is_disabled' => '1',
+        ]);
+
+        $this->assertRedirectContains('/awards/awards/view/' . $award->id);
+
+        $updatedAward = $awards->get($award->id);
+        $this->assertFalse((bool)$updatedAward->is_active);
+    }
+
+    public function testGridDataShowsDisabledColumnAndFiltersDisabledAwards(): void
+    {
+        $awards = $this->getTableLocator()->get('Awards.Awards');
+        $suffix = uniqid();
+
+        $activeAward = $awards->saveOrFail($awards->newEntity([
+            'name' => 'Grid Active Award ' . $suffix,
+            'abbreviation' => 'GAA-' . $suffix,
+            'domain_id' => 2,
+            'level_id' => 1,
+            'branch_id' => 27,
+            'is_active' => true,
+        ]));
+
+        $disabledAward = $awards->saveOrFail($awards->newEntity([
+            'name' => 'Grid Disabled Award ' . $suffix,
+            'abbreviation' => 'GDA-' . $suffix,
+            'domain_id' => 2,
+            'level_id' => 1,
+            'branch_id' => 27,
+            'is_active' => false,
+        ]));
+
+        $this->get('/awards/awards/grid-data?' . http_build_query([
+            'search' => $suffix,
+            'filter' => [
+                'disabled' => '0',
+            ],
+        ]));
+
+        $this->assertResponseOk();
+        $this->assertResponseContains('Disabled');
+        $this->assertResponseContains($disabledAward->name);
+        $this->assertResponseNotContains($activeAward->name);
+    }
+
+    public function testActivityAwardsGridDataUsesSharedGridWithRemoveAction(): void
+    {
+        $gatheringActivities = $this->getTableLocator()->get('GatheringActivities');
+        $awards = $this->getTableLocator()->get('Awards.Awards');
+        $awardGatheringActivities = $this->getTableLocator()->get('Awards.AwardGatheringActivities');
+        $suffix = uniqid();
+
+        $gatheringActivity = $gatheringActivities->saveOrFail($gatheringActivities->newEntity([
+            'name' => 'Awards Grid Activity ' . $suffix,
+            'description' => 'Activity for awards grid test',
+        ]));
+
+        $award = $awards->saveOrFail($awards->newEntity([
+            'name' => 'Activity Grid Award ' . $suffix,
+            'abbreviation' => 'AGA-' . $suffix,
+            'domain_id' => 2,
+            'level_id' => 1,
+            'branch_id' => 27,
+            'is_active' => true,
+        ]));
+
+        $awardGatheringActivities->saveOrFail($awardGatheringActivities->newEntity([
+            'award_id' => $award->id,
+            'gathering_activity_id' => $gatheringActivity->id,
+        ]));
+
+        $this->get('/awards/awards/activity-awards-grid-data/' . $gatheringActivity->id);
+
+        $this->assertResponseOk();
+        $this->assertResponseContains($award->name);
+        $this->assertResponseContains('/awards/awards/remove-activity/' . $award->id . '/' . $gatheringActivity->id);
+        $this->assertResponseContains('Disabled');
+    }
+}

--- a/app/plugins/Awards/tests/TestCase/Controller/RecommendationsControllerTest.php
+++ b/app/plugins/Awards/tests/TestCase/Controller/RecommendationsControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Awards\Test\TestCase\Controller;
 
 use App\Test\TestCase\Support\HttpIntegrationTestCase;
+use Awards\Model\Entity\Recommendation;
 use Cake\Cache\Cache;
 use Cake\I18n\DateTime;
 
@@ -180,5 +181,135 @@ class RecommendationsControllerTest extends HttpIntegrationTestCase
         $this->assertResponseOk();
         $this->assertResponseContains('Allowed gathering recommendation reason');
         $this->assertResponseNotContains('Blocked gathering recommendation reason');
+    }
+
+    public function testAwardsByDomainExcludesInactiveAwardsFromNewSelections(): void
+    {
+        $awards = $this->getTableLocator()->get('Awards.Awards');
+
+        $activeAward = $awards->save($awards->newEntity([
+            'name' => 'Selection Active Award ' . uniqid(),
+            'abbreviation' => 'SAA-' . uniqid(),
+            'domain_id' => 2,
+            'level_id' => 1,
+            'branch_id' => 27,
+            'is_active' => true,
+        ]));
+        $this->assertNotFalse($activeAward);
+        $this->createdAwardIds[] = $activeAward->id;
+
+        $inactiveAward = $awards->save($awards->newEntity([
+            'name' => 'Selection Inactive Award ' . uniqid(),
+            'abbreviation' => 'SIA-' . uniqid(),
+            'domain_id' => 2,
+            'level_id' => 1,
+            'branch_id' => 27,
+            'is_active' => false,
+        ]));
+        $this->assertNotFalse($inactiveAward);
+        $this->createdAwardIds[] = $inactiveAward->id;
+
+        $this->get('/awards/awards/awards-by-domain/2');
+
+        $this->assertResponseOk();
+        $response = json_decode((string)$this->_response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        $awardIds = array_column($response, 'id');
+
+        $this->assertContains($activeAward->id, $awardIds);
+        $this->assertNotContains($inactiveAward->id, $awardIds);
+    }
+
+    public function testAwardsByDomainKeepsCurrentInactiveAwardAvailableForExistingRecommendation(): void
+    {
+        $awards = $this->getTableLocator()->get('Awards.Awards');
+
+        $inactiveAward = $awards->save($awards->newEntity([
+            'name' => 'Existing Rec Inactive Award ' . uniqid(),
+            'abbreviation' => 'ERI-' . uniqid(),
+            'domain_id' => 2,
+            'level_id' => 1,
+            'branch_id' => 27,
+            'is_active' => false,
+        ]));
+        $this->assertNotFalse($inactiveAward);
+        $this->createdAwardIds[] = $inactiveAward->id;
+
+        $this->get('/awards/awards/awards-by-domain/2?current_award_id=' . $inactiveAward->id);
+
+        $this->assertResponseOk();
+        $response = json_decode((string)$this->_response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        $awardIds = array_column($response, 'id');
+
+        $this->assertContains($inactiveAward->id, $awardIds);
+    }
+
+    public function testInactiveAwardsCannotBeUsedForNewRecommendationsButExistingRecommendationsCanKeepThem(): void
+    {
+        $awards = $this->getTableLocator()->get('Awards.Awards');
+        $recommendations = $this->getTableLocator()->get('Awards.Recommendations');
+
+        $inactiveAward = $awards->save($awards->newEntity([
+            'name' => 'Inactive Recommendation Award ' . uniqid(),
+            'abbreviation' => 'IRA-' . uniqid(),
+            'domain_id' => 2,
+            'level_id' => 1,
+            'branch_id' => 27,
+            'is_active' => false,
+        ]));
+        $this->assertNotFalse($inactiveAward);
+        $this->createdAwardIds[] = $inactiveAward->id;
+
+        $newRecommendation = $recommendations->newEntity($this->buildRecommendationData($inactiveAward->id, 'inactive-award-new-rec-' . uniqid()));
+        $this->assertFalse($recommendations->save($newRecommendation));
+        $this->assertArrayHasKey('award_id', $newRecommendation->getErrors());
+
+        $activeAward = $awards->save($awards->newEntity([
+            'name' => 'Active Recommendation Award ' . uniqid(),
+            'abbreviation' => 'ARA-' . uniqid(),
+            'domain_id' => 2,
+            'level_id' => 1,
+            'branch_id' => 27,
+            'is_active' => true,
+        ]));
+        $this->assertNotFalse($activeAward);
+        $this->createdAwardIds[] = $activeAward->id;
+
+        $existingRecommendation = $recommendations->save($recommendations->newEntity(
+            $this->buildRecommendationData($activeAward->id, 'active-award-existing-rec-' . uniqid()),
+        ));
+        $this->assertNotFalse($existingRecommendation);
+        $this->createdRecommendationIds[] = $existingRecommendation->id;
+
+        $activeAward->is_active = false;
+        $this->assertNotFalse($awards->save($activeAward));
+
+        $existingRecommendation->reason = 'existing-inactive-award-kept-' . uniqid();
+        $savedExistingRecommendation = $recommendations->save($existingRecommendation);
+
+        $this->assertNotFalse($savedExistingRecommendation);
+        $this->assertSame($activeAward->id, $savedExistingRecommendation->award_id);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildRecommendationData(int $awardId, string $reason): array
+    {
+        return [
+            'requester_id' => self::ADMIN_MEMBER_ID,
+            'member_id' => self::ADMIN_MEMBER_ID,
+            'branch_id' => self::KINGDOM_BRANCH_ID,
+            'award_id' => $awardId,
+            'status' => 'To Give',
+            'state' => Recommendation::getStatuses()['To Give'][0],
+            'state_date' => DateTime::now(),
+            'requester_sca_name' => 'Admin von Admin',
+            'member_sca_name' => 'Admin von Admin',
+            'contact_email' => 'admin@amp.ansteorra.org',
+            'contact_number' => '555-555-0100',
+            'reason' => $reason,
+            'call_into_court' => 'No',
+            'court_availability' => 'Anytime',
+        ];
     }
 }

--- a/app/plugins/Awards/tests/TestCase/Model/Table/RecommendationsTableTest.php
+++ b/app/plugins/Awards/tests/TestCase/Model/Table/RecommendationsTableTest.php
@@ -48,7 +48,7 @@ class RecommendationsTableTest extends BaseTestCase
 
         $savedRecommendation = $this->Recommendations->save($recommendation);
 
-        $this->assertNotFalse($savedRecommendation);
+        $this->assertInstanceOf(Recommendation::class, $savedRecommendation);
         $this->assertSame($activeAward->id, $savedRecommendation->award_id);
     }
 

--- a/app/plugins/Awards/tests/TestCase/Model/Table/RecommendationsTableTest.php
+++ b/app/plugins/Awards/tests/TestCase/Model/Table/RecommendationsTableTest.php
@@ -1,0 +1,110 @@
+<?php
+declare(strict_types=1);
+
+namespace Awards\Test\TestCase\Model\Table;
+
+use App\Test\TestCase\BaseTestCase;
+use Awards\Model\Entity\Recommendation;
+use Awards\Model\Table\RecommendationsTable;
+use Cake\I18n\DateTime;
+
+class RecommendationsTableTest extends BaseTestCase
+{
+    private RecommendationsTable $Recommendations;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->Recommendations = $this->getTableLocator()->get('Awards.Recommendations');
+    }
+
+    public function testSaveRejectsNewRecommendationWithInactiveAward(): void
+    {
+        $inactiveAward = $this->createAward(false, 'Model Rule Inactive Award');
+
+        $recommendation = $this->Recommendations->newEntity(
+            $this->buildRecommendationData($inactiveAward->id, 'reject-inactive-new-' . uniqid('', true)),
+        );
+
+        $this->assertFalse($this->Recommendations->save($recommendation));
+        $this->assertContains(
+            'This award is inactive and can no longer be selected for new recommendations.',
+            $recommendation->getError('award_id'),
+        );
+    }
+
+    public function testSaveAllowsExistingRecommendationToKeepInactiveAwardWhenAwardUnchanged(): void
+    {
+        $activeAward = $this->createAward(true, 'Model Rule Active Award');
+
+        $recommendation = $this->Recommendations->saveOrFail($this->Recommendations->newEntity(
+            $this->buildRecommendationData($activeAward->id, 'keep-inactive-existing-' . uniqid('', true)),
+        ));
+
+        $activeAward->is_active = false;
+        $this->Recommendations->Awards->saveOrFail($activeAward);
+
+        $recommendation->reason = 'keep-inactive-existing-updated-' . uniqid('', true);
+
+        $savedRecommendation = $this->Recommendations->save($recommendation);
+
+        $this->assertNotFalse($savedRecommendation);
+        $this->assertSame($activeAward->id, $savedRecommendation->award_id);
+    }
+
+    public function testSaveRejectsExistingRecommendationWhenSwitchingToInactiveAward(): void
+    {
+        $activeAward = $this->createAward(true, 'Model Rule Current Active Award');
+        $inactiveAward = $this->createAward(false, 'Model Rule Target Inactive Award');
+
+        $recommendation = $this->Recommendations->saveOrFail($this->Recommendations->newEntity(
+            $this->buildRecommendationData($activeAward->id, 'switch-to-inactive-' . uniqid('', true)),
+        ));
+
+        $recommendation->award_id = $inactiveAward->id;
+
+        $this->assertFalse($this->Recommendations->save($recommendation));
+        $this->assertContains(
+            'This award is inactive and can no longer be selected for new recommendations.',
+            $recommendation->getError('award_id'),
+        );
+    }
+
+    /**
+     * @return \Awards\Model\Entity\Award
+     */
+    private function createAward(bool $isActive, string $namePrefix)
+    {
+        return $this->Recommendations->Awards->saveOrFail($this->Recommendations->Awards->newEntity([
+            'name' => $namePrefix . ' ' . uniqid('', true),
+            'abbreviation' => strtoupper(substr(md5(uniqid('', true)), 0, 8)),
+            'domain_id' => 2,
+            'level_id' => 1,
+            'branch_id' => 27,
+            'is_active' => $isActive,
+        ]));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildRecommendationData(int $awardId, string $reason): array
+    {
+        return [
+            'requester_id' => self::ADMIN_MEMBER_ID,
+            'member_id' => self::ADMIN_MEMBER_ID,
+            'branch_id' => self::KINGDOM_BRANCH_ID,
+            'award_id' => $awardId,
+            'status' => 'To Give',
+            'state' => Recommendation::getStatuses()['To Give'][0],
+            'state_date' => DateTime::now(),
+            'requester_sca_name' => 'Admin von Admin',
+            'member_sca_name' => 'Admin von Admin',
+            'contact_email' => 'admin@amp.ansteorra.org',
+            'contact_number' => '555-555-0100',
+            'reason' => $reason,
+            'call_into_court' => 'No',
+            'court_availability' => 'Anytime',
+        ];
+    }
+}

--- a/app/templates/element/dataverse_table_row_actions.php
+++ b/app/templates/element/dataverse_table_row_actions.php
@@ -43,6 +43,20 @@ $processTemplate = function ($template, $data) use ($getNestedValue) {
     }, $template);
 };
 
+/**
+ * Append additional URL path arguments from static values or row fields.
+ */
+$appendExtraArgs = function (array &$urlParams, array $extraArgs, $data) use ($getNestedValue) {
+    foreach ($extraArgs as $extraArg) {
+        if (is_array($extraArg) && isset($extraArg['field'])) {
+            $urlParams[] = $getNestedValue($extraArg['field'], $data);
+            continue;
+        }
+
+        $urlParams[] = $extraArg;
+    }
+};
+
 foreach ($actions as $action):
     // Check status filter (only show action for certain statuses)
     if (!empty($action['statusFilter'])) {
@@ -150,6 +164,9 @@ foreach ($actions as $action):
             if (!empty($url['idField'])) {
                 $urlParams[] = $getNestedValue($url['idField'], $row);
             }
+            if (!empty($url['extraArgs']) && is_array($url['extraArgs'])) {
+                $appendExtraArgs($urlParams, $url['extraArgs'], $row);
+            }
 
             // Build confirm message
             $confirmMessage = null;
@@ -157,18 +174,32 @@ foreach ($actions as $action):
                 $confirmMessage = $processTemplate($action['confirmMessage'], $row);
             }
 
-            // Wrap in data-turbo="false" to prevent Turbo from intercepting
-            // the form submission. CakePHP's postLink uses requestSubmit()
-            // which fires a submit event Turbo would otherwise capture,
-            // causing a TurboFrameMissingError when the redirect response
-            // doesn't contain the expected turbo-frame.
-            echo '<div data-turbo="false" style="display:contents;">';
-            echo $this->Form->postLink($label, $urlParams, [
+            $postLinkOptions = [
                 'escape' => false,
                 'class' => $buttonClass,
                 'confirm' => $confirmMessage,
-            ]);
-            echo '</div> ';
+            ];
+
+            if (!empty($action['turbo'])) {
+                $postLinkOptions['data-turbo'] = 'true';
+            }
+
+            if (empty($action['turbo'])) {
+                // Wrap in data-turbo="false" to prevent Turbo from intercepting
+                // the form submission. CakePHP's postLink uses requestSubmit()
+                // which fires a submit event Turbo would otherwise capture,
+                // causing a TurboFrameMissingError when the redirect response
+                // doesn't contain the expected turbo-frame.
+                echo '<div data-turbo="false" style="display:contents;">';
+            }
+
+            echo $this->Form->postLink($label, $urlParams, $postLinkOptions);
+
+            if (empty($action['turbo'])) {
+                echo '</div> ';
+            } else {
+                echo ' ';
+            }
             break;
 
         case 'link':
@@ -183,6 +214,9 @@ foreach ($actions as $action):
             // Add the ID from the row
             if (!empty($url['idField'])) {
                 $urlParams[] = $getNestedValue($url['idField'], $row);
+            }
+            if (!empty($url['extraArgs']) && is_array($url['extraArgs'])) {
+                $appendExtraArgs($urlParams, $url['extraArgs'], $row);
             }
 
             echo $this->Html->link($label, $urlParams, [

--- a/app/tests/bootstrap.php
+++ b/app/tests/bootstrap.php
@@ -99,13 +99,14 @@ SeedManager::bootstrap('test');
 // Apply migrations after seeding so test schema includes recent columns.
 (new Migrations())->migrate(['connection' => 'test']);
 
-// On Postgres (no MySQL seed dump), we also need to run plugin migrations
-// to create all plugin tables from scratch, and seed essential AppSettings.
-if (SeedManager::isPostgres('test')) {
-    foreach (['Queue', 'Officers', 'Activities', 'Awards', 'Waivers'] as $plugin) {
-        (new Migrations())->migrate(['connection' => 'test', 'plugin' => $plugin]);
-    }
+// Apply plugin migrations on every test connection so pending plugin schema changes
+// are layered on top of the shared seed dump as soon as they are added.
+foreach (['Queue', 'Officers', 'Activities', 'Awards', 'Waivers'] as $plugin) {
+    (new Migrations())->migrate(['connection' => 'test', 'plugin' => $plugin]);
+}
 
+// On Postgres (no MySQL seed dump), we also need to seed essential AppSettings.
+if (SeedManager::isPostgres('test')) {
     // Seed essential AppSettings that tests expect
     $conn = ConnectionManager::get('test');
     $now = date('Y-m-d H:i:s');

--- a/app/webroot/js/manifest.js
+++ b/app/webroot/js/manifest.js
@@ -56,7 +56,7 @@
 /******/ 				var priority = deferred[i][2];
 /******/ 				var fulfilled = true;
 /******/ 				for (var j = 0; j < chunkIds.length; j++) {
-/******/ 					if (((priority & 1) === 0 || notFulfilled >= priority) && Object.keys(__webpack_require__.O).every(function(key) { return __webpack_require__.O[key](chunkIds[j]); })) {
+/******/ 					if ((priority & 1 === 0 || notFulfilled >= priority) && Object.keys(__webpack_require__.O).every(function(key) { return __webpack_require__.O[key](chunkIds[j]); })) {
 /******/ 						chunkIds.splice(j--, 1);
 /******/ 					} else {
 /******/ 						fulfilled = false;

--- a/app/webroot/mix-manifest.json
+++ b/app/webroot/mix-manifest.json
@@ -1,6 +1,6 @@
 {
-    "/js/controllers.js": "/js/controllers.js?id=38cfa6e45d27288e4a0f49b15db7f0d3",
-    "/js/controllers.js.map": "/js/controllers.js.map?id=9f473600b1a03ecc5228ebd206730553",
+    "/js/controllers.js": "/js/controllers.js?id=d62eb6641e2b91d8c5cb391f9b4f10ab",
+    "/js/controllers.js.map": "/js/controllers.js.map?id=8e05b09768b81eb2eef1e493ffc5a4f7",
     "/js/index.js": "/js/index.js?id=05d7f1033862d7be58ed727b7d7c2cc7",
     "/js/index.js.map": "/js/index.js.map?id=ffe305d280ef46561da898234956c04b",
     "/js/manifest.js": "/js/manifest.js?id=a1879ee9d08c6841b38c934bfb04a4dc",


### PR DESCRIPTION
## Summary
- add the Awards plugin `is_active` hotfix migration with a safe sequence before pending feature-branch migrations
- block inactive awards from new recommendation selection while allowing existing recommendations to keep their current award
- expose the disabled flag in award admin UI and grids, and switch activity awards to the shared Awards dataverse grid

## Testing
- vendor/bin/phpunit plugins/Awards/tests/TestCase/Model/Table/RecommendationsTableTest.php
- vendor/bin/phpunit plugins/Awards/tests/TestCase/Controller/RecommendationsControllerTest.php plugins/Awards/tests/TestCase/Controller/AwardsControllerTest.php
- bash bin/verify.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Awards can now be marked as disabled, controlling visibility in recommendation forms
  * New grid interface for managing awards linked to activities
  * Award recommendations display only active awards by default while preserving previously selected inactive award references

* **Tests**
  * Expanded test coverage for award status management and recommendation validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->