### PR TITLE
Add schema-aware backup restore flow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -37,6 +37,10 @@ app/.editorconfig
 docker/Dockerfile.app
 docker/entrypoint.sh
 docker/.env.example
+!docker/Dockerfile.app
+!docker/entrypoint.sh
+!docker/app_local.php
+!docker/apache-vhost.conf
 
 # Dev scripts
 dev-up.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -37,7 +37,6 @@ app/.editorconfig
 docker/Dockerfile.app
 docker/entrypoint.sh
 docker/.env.example
-!docker/Dockerfile.app
 !docker/entrypoint.sh
 !docker/app_local.php
 !docker/apache-vhost.conf

--- a/app/assets/js/controllers/backup-restore-status-controller.js
+++ b/app/assets/js/controllers/backup-restore-status-controller.js
@@ -20,6 +20,7 @@ class BackupRestoreStatusController extends Controller {
         "modalBadge",
         "modalMessage",
         "modalDetails",
+        "modalLog",
         "modalSpinner",
         "modalClose"
     ]
@@ -221,6 +222,7 @@ class BackupRestoreStatusController extends Controller {
         const rowsProcessed = Number(status?.rows_processed || 0)
         const source = status?.source || ''
         const currentTable = status?.current_table || ''
+        const log = Array.isArray(status?.log) ? status.log : []
         const message = state === 'idle'
             ? 'No restore currently running.'
             : (status?.message || 'No restore currently running.')
@@ -248,6 +250,7 @@ class BackupRestoreStatusController extends Controller {
             badgeClass: this.badgeClass(locked, state),
             panelClass: this.panelClass(locked, state),
             showSpinner: locked || state === 'running',
+            log,
         }
     }
 
@@ -311,6 +314,9 @@ class BackupRestoreStatusController extends Controller {
         if (this.hasModalDetailsTarget) {
             this.modalDetailsTarget.textContent = normalizedStatus.details
         }
+        if (this.hasModalLogTarget) {
+            this.renderLog(this.modalLogTarget, normalizedStatus.log)
+        }
         if (this.hasModalSpinnerTarget) {
             this.modalSpinnerTarget.classList.toggle('d-none', !normalizedStatus.showSpinner)
         }
@@ -318,6 +324,25 @@ class BackupRestoreStatusController extends Controller {
         if (this.restoreRequestInFlight || normalizedStatus.showSpinner) {
             this.modalInstance.show()
         }
+    }
+
+    renderLog(target, log) {
+        const entries = Array.isArray(log) ? log.slice(-20) : []
+        if (entries.length === 0) {
+            const item = document.createElement('li')
+            item.textContent = 'No restore log entries have been written yet.'
+            target.replaceChildren(item)
+
+            return
+        }
+
+        target.replaceChildren(...entries.map((entry) => {
+            const item = document.createElement('li')
+            const timestamp = entry?.timestamp ? `${entry.timestamp}: ` : ''
+            item.textContent = `${timestamp}${entry?.message || ''}`
+
+            return item
+        }))
     }
 
     showModal(normalizedStatus) {

--- a/app/assets/js/controllers/backup-restore-status-controller.js
+++ b/app/assets/js/controllers/backup-restore-status-controller.js
@@ -105,22 +105,13 @@ class BackupRestoreStatusController extends Controller {
             if (!response.ok || payload?.success === false) {
                 throw new Error(payload?.message || 'Restore request failed.')
             }
-            this.awaitingFreshRunningState = false
-            this.hasSeenRunningState = true
-
-            const completedStatus = {
-                locked: false,
-                status: 'completed',
-                phase: 'completed',
-                message: payload?.message || 'Restore/import completed.',
-                table_count: payload?.stats?.table_count,
-                tables_processed: payload?.stats?.table_count,
-                row_count: payload?.stats?.row_count,
-                rows_processed: payload?.stats?.row_count,
-                completed_at: new Date().toISOString(),
+            const startedStatus = payload?.status || {
+                locked: true,
+                status: 'running',
+                phase: 'queued',
+                message: payload?.message || 'Restore started.',
             }
-            this.render(completedStatus)
-            this.scheduleReload()
+            this.render(startedStatus)
             await this.pollStatus(true)
         } catch (error) {
             const failedStatus = {

--- a/app/assets/js/controllers/backup-restore-status-controller.js
+++ b/app/assets/js/controllers/backup-restore-status-controller.js
@@ -112,6 +112,7 @@ class BackupRestoreStatusController extends Controller {
                 message: payload?.message || 'Restore started.',
             }
             this.render(startedStatus)
+            this.awaitingFreshRunningState = false
             await this.pollStatus(true)
         } catch (error) {
             const failedStatus = {

--- a/app/config/app.php
+++ b/app/config/app.php
@@ -57,7 +57,7 @@ if ($cacheEngine === RedisEngine::class) {
         ];
     }
 }
-$restoreStatusPath = env('RESTORE_STATUS_CACHE_PATH', sys_get_temp_dir() . DS . 'kmp_restore_status_shared' . DS);
+$restoreStatusPath = env('RESTORE_STATUS_CACHE_PATH', TMP . 'restore_status' . DS);
 if (!is_dir($restoreStatusPath)) {
     @mkdir($restoreStatusPath, 0777, true);
 }

--- a/app/src/Application.php
+++ b/app/src/Application.php
@@ -51,6 +51,7 @@ namespace App;
 use App\KMP\KmpIdentityInterface;
 // Add this line
 use App\KMP\StaticHelpers;
+use App\Middleware\RestoreMaintenanceMiddleware;
 use App\KMP\Telemetry\RequestQueryCounter;
 // Authorization usings
 use App\Policy\ControllerResolver;
@@ -569,6 +570,9 @@ class Application extends BaseApplication implements
                     'cacheTime' => Configure::read('Asset.cacheTime'), // Use configured cache time
                 ]),
             )
+
+            // 4b. Restore maintenance gate - blocks normal traffic while DB schema is being reset.
+            ->add(new RestoreMaintenanceMiddleware())
 
             // 5. Routing Middleware - URL to controller/action mapping
             // For large applications, consider enabling route caching in production

--- a/app/src/Command/BackupCommand.php
+++ b/app/src/Command/BackupCommand.php
@@ -11,6 +11,7 @@ use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Exception;
+use RuntimeException;
 
 /**
  * CLI backup management: create and restore backups.
@@ -235,7 +236,10 @@ class BackupCommand extends Command
                     }
                 },
                 function () use ($io): void {
-                    $this->executeCommand(UpdateDatabaseCommand::class, [], $io);
+                    $exitCode = $this->executeCommand(UpdateDatabaseCommand::class, [], $io);
+                    if ($exitCode !== null && $exitCode !== self::CODE_SUCCESS) {
+                        throw new RuntimeException('Database migrations failed during restore.');
+                    }
                 },
             );
 

--- a/app/src/Command/BackupCommand.php
+++ b/app/src/Command/BackupCommand.php
@@ -234,6 +234,9 @@ class BackupCommand extends Command
                         $lastPhase = $phase;
                     }
                 },
+                function () use ($io): void {
+                    $this->executeCommand(UpdateDatabaseCommand::class, [], $io);
+                },
             );
 
             $restoreStatusService->markCompleted(sprintf(

--- a/app/src/Command/BackupRestoreRunCommand.php
+++ b/app/src/Command/BackupRestoreRunCommand.php
@@ -3,21 +3,16 @@ declare(strict_types=1);
 
 namespace App\Command;
 
-use App\Services\BackupService;
-use App\Services\RestoreStagingService;
-use App\Services\RestoreStatusService;
+use App\Services\BackupRestoreRunnerService;
 use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
-use Cake\I18n\DateTime;
-use Cake\Log\Log;
-use Cake\ORM\TableRegistry;
 use RuntimeException;
 use Throwable;
 
 /**
- * Internal restore runner for web-initiated background restores.
+ * Internal restore runner for manually resuming staged restores from CLI.
  */
 class BackupRestoreRunCommand extends Command
 {
@@ -60,53 +55,12 @@ class BackupRestoreRunCommand extends Command
     {
         $token = (string)$args->getArgument('token');
         $restoreId = (string)($args->getArgument('restore_id') ?? '');
-        $restoreStatusService = new RestoreStatusService();
-        $ownsRestoreLock = $restoreId !== '' && $this->restoreIdMatchesCurrentLock($restoreStatusService, $restoreId);
-        $context = [
-            'restore_id' => $restoreId,
-        ];
 
         try {
-            if ($restoreStatusService->isLocked() && !$ownsRestoreLock) {
-                throw new RuntimeException('Restore lock belongs to a different restore operation.');
-            }
-
-            $staged = (new RestoreStagingService())->consume($token);
-            $context = $staged['context'];
-            if (
-                $restoreId !== ''
-                && (string)($context['restore_id'] ?? '') !== $restoreId
-            ) {
-                throw new RuntimeException('Restore staging token does not match the active restore.');
-            }
-
-            if (!$restoreStatusService->isLocked()) {
-                if (!$restoreStatusService->acquireLock(array_merge($context, [
-                    'message' => 'Restore runner recovered missing restore lock.',
-                ]))) {
-                    throw new RuntimeException('Unable to acquire restore lock for runner.');
-                }
-                $ownsRestoreLock = true;
-            } else {
-                $ownsRestoreLock = true;
-            }
-
-            $restoreStatusService->updateStatus('starting', 'Background restore runner started.', $context);
-            $lastPhase = null;
-            $stats = (new BackupService())->import(
-                $staged['encrypted_data'],
-                $staged['encryption_key'],
-                function (array $progress) use ($restoreStatusService, $context, $io, &$lastPhase): void {
-                    $phase = (string)($progress['phase'] ?? 'running');
-                    $message = (string)($progress['message'] ?? 'Restore in progress.');
-                    unset($progress['phase'], $progress['message']);
-                    $restoreStatusService->updateStatus($phase, $message, array_merge($progress, $context));
-
-                    if ($phase !== $lastPhase) {
-                        $io->out($message);
-                        $lastPhase = $phase;
-                    }
-                },
+            (new BackupRestoreRunnerService())->run(
+                $token,
+                $restoreId,
+                fn(string $message): ?int => $io->out($message),
                 function () use ($io): void {
                     $exitCode = $this->executeCommand(UpdateDatabaseCommand::class, [], $io);
                     if ($exitCode !== null && $exitCode !== self::CODE_SUCCESS) {
@@ -115,94 +69,11 @@ class BackupRestoreRunCommand extends Command
                 },
             );
 
-            $this->updateTrackedBackupStatus($context, 'completed', sprintf(
-                'Restore completed at %s: %d tables, %d rows.',
-                DateTime::now()->format('Y-m-d H:i:s'),
-                $stats['table_count'],
-                $stats['row_count'],
-            ), $stats);
-            $restoreStatusService->markCompleted(sprintf(
-                'Restore/import completed: %d tables, %d rows.',
-                $stats['table_count'],
-                $stats['row_count'],
-            ), array_merge($context, [
-                'table_count' => $stats['table_count'],
-                'tables_processed' => $stats['table_count'],
-                'row_count' => $stats['row_count'],
-                'rows_processed' => $stats['row_count'],
-            ]));
-
             return self::CODE_SUCCESS;
         } catch (Throwable $e) {
-            if ($ownsRestoreLock) {
-                $this->updateTrackedBackupStatus($context, 'failed', sprintf(
-                    'Restore failed at %s: %s',
-                    DateTime::now()->format('Y-m-d H:i:s'),
-                    $e->getMessage(),
-                ));
-                $restoreStatusService->markFailed('Restore/import failed: ' . $e->getMessage());
-            }
             $io->error('Restore failed: ' . $e->getMessage());
 
             return self::CODE_ERROR;
-        } finally {
-            if ($ownsRestoreLock) {
-                $restoreStatusService->releaseLock();
-            }
-        }
-    }
-
-    /**
-     * Check whether the active lock belongs to this restore runner.
-     */
-    private function restoreIdMatchesCurrentLock(RestoreStatusService $restoreStatusService, string $restoreId): bool
-    {
-        $status = $restoreStatusService->getStatus();
-
-        return (string)($status['restore_id'] ?? '') === $restoreId;
-    }
-
-    /**
-     * Persist final async restore status to the tracked backup row when available.
-     *
-     * @param array<string, mixed> $context
-     * @param array{table_count: int, row_count: int}|null $stats
-     */
-    private function updateTrackedBackupStatus(
-        array $context,
-        string $status,
-        string $notes,
-        ?array $stats = null,
-    ): void {
-        $backupId = $context['backup_id'] ?? null;
-        if ($backupId === null || $backupId === '') {
-            return;
-        }
-
-        try {
-            $backups = TableRegistry::getTableLocator()->get('Backups');
-            $backup = $backups->find()->where(['id' => $backupId])->first();
-            if ($backup === null) {
-                $backup = $backups->newEntity([
-                    'id' => $backupId,
-                    'filename' => (string)($context['source'] ?? 'Restored backup'),
-                    'storage_type' => 'local',
-                ], ['accessibleFields' => [
-                    'id' => true,
-                    'filename' => true,
-                    'storage_type' => true,
-                ]]);
-            }
-
-            $backup->status = $status;
-            $backup->notes = $notes;
-            if ($stats !== null) {
-                $backup->table_count = $stats['table_count'];
-                $backup->row_count = $stats['row_count'];
-            }
-            $backups->saveOrFail($backup);
-        } catch (Throwable $e) {
-            Log::warning('Unable to update backup restore status row: ' . $e->getMessage());
         }
     }
 }

--- a/app/src/Command/BackupRestoreRunCommand.php
+++ b/app/src/Command/BackupRestoreRunCommand.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Services\BackupService;
+use App\Services\RestoreStagingService;
+use App\Services\RestoreStatusService;
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Exception;
+
+/**
+ * Internal restore runner for web-initiated background restores.
+ */
+class BackupRestoreRunCommand extends Command
+{
+    public static function defaultName(): string
+    {
+        return 'backup_restore_run';
+    }
+
+    protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
+    {
+        return $parser
+            ->setDescription('Internal command that runs a staged backup restore.')
+            ->addArgument('token', [
+                'help' => 'Restore staging token',
+                'required' => true,
+            ]);
+    }
+
+    public function execute(Arguments $args, ConsoleIo $io): ?int
+    {
+        $token = (string)$args->getArgument('token');
+        $restoreStatusService = new RestoreStatusService();
+
+        try {
+            $staged = (new RestoreStagingService())->consume($token);
+            $context = $staged['context'];
+            if (!$restoreStatusService->isLocked()) {
+                $restoreStatusService->acquireLock(array_merge($context, [
+                    'message' => 'Restore runner recovered missing restore lock.',
+                ]));
+            }
+
+            $restoreStatusService->updateStatus('starting', 'Background restore runner started.', $context);
+            $lastPhase = null;
+            $stats = (new BackupService())->import(
+                $staged['encrypted_data'],
+                $staged['encryption_key'],
+                function (array $progress) use ($restoreStatusService, $context, $io, &$lastPhase): void {
+                    $phase = (string)($progress['phase'] ?? 'running');
+                    $message = (string)($progress['message'] ?? 'Restore in progress.');
+                    unset($progress['phase'], $progress['message']);
+                    $restoreStatusService->updateStatus($phase, $message, array_merge($progress, $context));
+
+                    if ($phase !== $lastPhase) {
+                        $io->out($message);
+                        $lastPhase = $phase;
+                    }
+                },
+                function () use ($io): void {
+                    $this->executeCommand(UpdateDatabaseCommand::class, [], $io);
+                },
+            );
+
+            $restoreStatusService->markCompleted(sprintf(
+                'Restore/import completed: %d tables, %d rows.',
+                $stats['table_count'],
+                $stats['row_count'],
+            ), array_merge($context, [
+                'table_count' => $stats['table_count'],
+                'tables_processed' => $stats['table_count'],
+                'row_count' => $stats['row_count'],
+                'rows_processed' => $stats['row_count'],
+            ]));
+
+            return self::CODE_SUCCESS;
+        } catch (Exception $e) {
+            $restoreStatusService->markFailed('Restore/import failed: ' . $e->getMessage());
+            $io->error('Restore failed: ' . $e->getMessage());
+
+            return self::CODE_ERROR;
+        } finally {
+            $restoreStatusService->releaseLock();
+        }
+    }
+}

--- a/app/src/Command/BackupRestoreRunCommand.php
+++ b/app/src/Command/BackupRestoreRunCommand.php
@@ -10,18 +10,31 @@ use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
-use Exception;
+use Cake\I18n\DateTime;
+use Cake\Log\Log;
+use Cake\ORM\TableRegistry;
+use RuntimeException;
+use Throwable;
 
 /**
  * Internal restore runner for web-initiated background restores.
  */
 class BackupRestoreRunCommand extends Command
 {
+    /**
+     * Return the internal restore runner command name.
+     */
     public static function defaultName(): string
     {
         return 'backup_restore_run';
     }
 
+    /**
+     * Configure the restore token and ownership arguments.
+     *
+     * @param \Cake\Console\ConsoleOptionParser $parser Console option parser
+     * @return \Cake\Console\ConsoleOptionParser
+     */
     protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         return $parser
@@ -29,21 +42,53 @@ class BackupRestoreRunCommand extends Command
             ->addArgument('token', [
                 'help' => 'Restore staging token',
                 'required' => true,
+            ])
+            ->addArgument('restore_id', [
+                'help' => 'Restore ownership identifier',
+                'required' => true,
             ]);
     }
 
+    /**
+     * Run a staged restore and return the command exit code.
+     *
+     * @param \Cake\Console\Arguments $args Command arguments
+     * @param \Cake\Console\ConsoleIo $io Console IO
+     * @return int|null
+     */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $token = (string)$args->getArgument('token');
+        $restoreId = (string)($args->getArgument('restore_id') ?? '');
         $restoreStatusService = new RestoreStatusService();
+        $ownsRestoreLock = $restoreId !== '' && $this->restoreIdMatchesCurrentLock($restoreStatusService, $restoreId);
+        $context = [
+            'restore_id' => $restoreId,
+        ];
 
         try {
+            if ($restoreStatusService->isLocked() && !$ownsRestoreLock) {
+                throw new RuntimeException('Restore lock belongs to a different restore operation.');
+            }
+
             $staged = (new RestoreStagingService())->consume($token);
             $context = $staged['context'];
+            if (
+                $restoreId !== ''
+                && (string)($context['restore_id'] ?? '') !== $restoreId
+            ) {
+                throw new RuntimeException('Restore staging token does not match the active restore.');
+            }
+
             if (!$restoreStatusService->isLocked()) {
-                $restoreStatusService->acquireLock(array_merge($context, [
+                if (!$restoreStatusService->acquireLock(array_merge($context, [
                     'message' => 'Restore runner recovered missing restore lock.',
-                ]));
+                ]))) {
+                    throw new RuntimeException('Unable to acquire restore lock for runner.');
+                }
+                $ownsRestoreLock = true;
+            } else {
+                $ownsRestoreLock = true;
             }
 
             $restoreStatusService->updateStatus('starting', 'Background restore runner started.', $context);
@@ -63,10 +108,19 @@ class BackupRestoreRunCommand extends Command
                     }
                 },
                 function () use ($io): void {
-                    $this->executeCommand(UpdateDatabaseCommand::class, [], $io);
+                    $exitCode = $this->executeCommand(UpdateDatabaseCommand::class, [], $io);
+                    if ($exitCode !== null && $exitCode !== self::CODE_SUCCESS) {
+                        throw new RuntimeException('Database migrations failed during restore.');
+                    }
                 },
             );
 
+            $this->updateTrackedBackupStatus($context, 'completed', sprintf(
+                'Restore completed at %s: %d tables, %d rows.',
+                DateTime::now()->format('Y-m-d H:i:s'),
+                $stats['table_count'],
+                $stats['row_count'],
+            ), $stats);
             $restoreStatusService->markCompleted(sprintf(
                 'Restore/import completed: %d tables, %d rows.',
                 $stats['table_count'],
@@ -79,13 +133,76 @@ class BackupRestoreRunCommand extends Command
             ]));
 
             return self::CODE_SUCCESS;
-        } catch (Exception $e) {
-            $restoreStatusService->markFailed('Restore/import failed: ' . $e->getMessage());
+        } catch (Throwable $e) {
+            if ($ownsRestoreLock) {
+                $this->updateTrackedBackupStatus($context, 'failed', sprintf(
+                    'Restore failed at %s: %s',
+                    DateTime::now()->format('Y-m-d H:i:s'),
+                    $e->getMessage(),
+                ));
+                $restoreStatusService->markFailed('Restore/import failed: ' . $e->getMessage());
+            }
             $io->error('Restore failed: ' . $e->getMessage());
 
             return self::CODE_ERROR;
         } finally {
-            $restoreStatusService->releaseLock();
+            if ($ownsRestoreLock) {
+                $restoreStatusService->releaseLock();
+            }
+        }
+    }
+
+    /**
+     * Check whether the active lock belongs to this restore runner.
+     */
+    private function restoreIdMatchesCurrentLock(RestoreStatusService $restoreStatusService, string $restoreId): bool
+    {
+        $status = $restoreStatusService->getStatus();
+
+        return (string)($status['restore_id'] ?? '') === $restoreId;
+    }
+
+    /**
+     * Persist final async restore status to the tracked backup row when available.
+     *
+     * @param array<string, mixed> $context
+     * @param array{table_count: int, row_count: int}|null $stats
+     */
+    private function updateTrackedBackupStatus(
+        array $context,
+        string $status,
+        string $notes,
+        ?array $stats = null,
+    ): void {
+        $backupId = $context['backup_id'] ?? null;
+        if ($backupId === null || $backupId === '') {
+            return;
+        }
+
+        try {
+            $backups = TableRegistry::getTableLocator()->get('Backups');
+            $backup = $backups->find()->where(['id' => $backupId])->first();
+            if ($backup === null) {
+                $backup = $backups->newEntity([
+                    'id' => $backupId,
+                    'filename' => (string)($context['source'] ?? 'Restored backup'),
+                    'storage_type' => 'local',
+                ], ['accessibleFields' => [
+                    'id' => true,
+                    'filename' => true,
+                    'storage_type' => true,
+                ]]);
+            }
+
+            $backup->status = $status;
+            $backup->notes = $notes;
+            if ($stats !== null) {
+                $backup->table_count = $stats['table_count'];
+                $backup->row_count = $stats['row_count'];
+            }
+            $backups->saveOrFail($backup);
+        } catch (Throwable $e) {
+            Log::warning('Unable to update backup restore status row: ' . $e->getMessage());
         }
     }
 }

--- a/app/src/Command/UpdateDatabaseCommand.php
+++ b/app/src/Command/UpdateDatabaseCommand.php
@@ -59,12 +59,21 @@ class UpdateDatabaseCommand extends Command
         }
         //sort
         asort($pluginsToMigrate);
-        $this->executeCommand(SchemacacheClearCommand::class, ['--connection', 'default'], $io);
+        $exitCode = $this->executeCommand(SchemacacheClearCommand::class, ['--connection', 'default'], $io);
+        if ($exitCode !== null && $exitCode !== Command::CODE_SUCCESS) {
+            return $exitCode;
+        }
         $frameworkMigration = new Migrate();
-        $this->executeCommand($frameworkMigration, ['migrate']);
+        $exitCode = $this->executeCommand($frameworkMigration, ['migrate'], $io);
+        if ($exitCode !== null && $exitCode !== Command::CODE_SUCCESS) {
+            return $exitCode;
+        }
         foreach ($pluginsToMigrate as $name => $order) {
             $pluginMigration = new Migrate();
-            $this->executeCommand($pluginMigration, ['migrate', '-p', $name]);
+            $exitCode = $this->executeCommand($pluginMigration, ['migrate', '-p', $name], $io);
+            if ($exitCode !== null && $exitCode !== Command::CODE_SUCCESS) {
+                return $exitCode;
+            }
         }
 
         return Command::CODE_SUCCESS;

--- a/app/src/Controller/BackupsController.php
+++ b/app/src/Controller/BackupsController.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Queue\Task\BackupRestoreTask;
 use App\Services\BackupService;
 use App\Services\BackupStorageService;
 use App\Services\RestoreStagingService;
@@ -11,7 +12,6 @@ use Cake\Http\Response;
 use Cake\I18n\DateTime;
 use Cake\Log\Log;
 use Psr\Http\Message\UploadedFileInterface;
-use RuntimeException;
 use Throwable;
 
 /**
@@ -241,13 +241,14 @@ class BackupsController extends AppController
                 'actor' => $actor,
                 'restore_id' => $restoreId,
             ]);
-            $this->launchRestoreRunner($token, $restoreId);
+            $restoreJob = $this->enqueueRestoreRunner($token, $restoreId);
 
             $restoreStatusService->updateStatus('queued', sprintf('Restore queued from %s.', $sourceLabel), [
                 'source' => $sourceLabel,
                 'backup_id' => $id,
                 'actor' => $actor,
                 'restore_id' => $restoreId,
+                'queue_job_id' => $restoreJob->id,
             ]);
 
             if ($expectsJson) {
@@ -293,32 +294,20 @@ class BackupsController extends AppController
     }
 
     /**
-     * Launch staged restore runner without exposing the encryption key in process args.
+     * Queue a staged restore runner without exposing the encryption key in process args.
      */
-    private function launchRestoreRunner(string $token, string $restoreId): void
+    private function enqueueRestoreRunner(string $token, string $restoreId): object
     {
-        $php = escapeshellarg(PHP_BINARY);
-        $cake = escapeshellarg(ROOT . DS . 'bin' . DS . 'cake');
-        $arg = escapeshellarg($token);
-        $restoreArg = escapeshellarg($restoreId);
+        $queuedJobs = $this->fetchTable('Queue.QueuedJobs');
 
-        if (PHP_OS_FAMILY === 'Windows') {
-            $process = popen("start /B {$php} {$cake} backup_restore_run {$arg} {$restoreArg}", 'r');
-            if ($process === false) {
-                throw new RuntimeException('Unable to launch restore runner process.');
-            }
-            $exitCode = pclose($process);
-            if ($exitCode !== 0) {
-                throw new RuntimeException('Restore runner process launch failed.');
-            }
-
-            return;
-        }
-
-        exec("nohup {$php} {$cake} backup_restore_run {$arg} {$restoreArg} > /dev/null 2>&1 &", $output, $exitCode);
-        if ($exitCode !== 0) {
-            throw new RuntimeException('Restore runner process launch failed.');
-        }
+        return $queuedJobs->createJob(BackupRestoreTask::class, [
+            'token' => $token,
+            'restore_id' => $restoreId,
+        ], [
+            'group' => 'backup_restore',
+            'reference' => 'restore-' . $restoreId,
+            'status' => 'Restore queued.',
+        ]);
     }
 
     /**

--- a/app/src/Controller/BackupsController.php
+++ b/app/src/Controller/BackupsController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 
 use App\Services\BackupService;
 use App\Services\BackupStorageService;
+use App\Services\RestoreStagingService;
 use App\Services\RestoreStatusService;
 use Cake\Http\Response;
 use Cake\I18n\DateTime;
@@ -142,7 +143,6 @@ class BackupsController extends AppController
             return $this->redirect(['action' => 'index']);
         }
 
-        $backupService = new BackupService();
         $restoreStatusService = new RestoreStatusService();
         $restoreTrackedBackup = null;
         $data = '';
@@ -231,82 +231,43 @@ class BackupsController extends AppController
                 $this->Backups->save($restoreTrackedBackup);
             }
 
-            $stats = $backupService->import(
-                $data,
-                $encryptionKey,
-                function (array $progress) use ($restoreStatusService, $sourceLabel, $id, $actor): void {
-                    $phase = (string)($progress['phase'] ?? 'running');
-                    $message = (string)($progress['message'] ?? 'Restore in progress.');
-                    unset($progress['phase'], $progress['message']);
-
-                    $restoreStatusService->updateStatus($phase, $message, array_merge($progress, [
-                        'source' => $sourceLabel,
-                        'backup_id' => $id,
-                        'actor' => $actor,
-                    ]));
-                },
-            );
-
-            if ($restoreTrackedBackup !== null) {
-                $restoreTrackedBackup->status = 'completed';
-                $restoreTrackedBackup->table_count = $stats['table_count'];
-                $restoreTrackedBackup->row_count = $stats['row_count'];
-                $restoreTrackedBackup->notes = __(
-                    'Restore completed at {0}: {1} tables, {2} rows.',
-                    date('Y-m-d H:i:s'),
-                    $stats['table_count'],
-                    $stats['row_count'],
-                );
-                $this->Backups->save($restoreTrackedBackup);
-            }
-
-            $restoreStatusService->markCompleted(sprintf(
-                'Restore/import completed from %s: %d tables, %d rows.',
-                $sourceLabel,
-                $stats['table_count'],
-                $stats['row_count'],
-            ), [
+            $token = (new RestoreStagingService())->stage($data, $encryptionKey, [
                 'source' => $sourceLabel,
                 'backup_id' => $id,
                 'actor' => $actor,
-                'table_count' => $stats['table_count'],
-                'tables_processed' => $stats['table_count'],
-                'row_count' => $stats['row_count'],
-                'rows_processed' => $stats['row_count'],
+            ]);
+            $this->launchRestoreRunner($token);
+
+            $restoreStatusService->updateStatus('queued', sprintf('Restore queued from %s.', $sourceLabel), [
+                'source' => $sourceLabel,
+                'backup_id' => $id,
+                'actor' => $actor,
             ]);
 
             if ($expectsJson) {
                 return $this->jsonResponse([
                     'success' => true,
-                    'message' => __(
-                        'Restore/import completed from {0}: {1} tables, {2} rows',
-                        $sourceLabel,
-                        $stats['table_count'],
-                        $stats['row_count'],
-                    ),
-                    'stats' => $stats,
-                ]);
+                    'message' => __('Restore started. Progress will continue in the background.'),
+                    'status' => $restoreStatusService->getStatus(),
+                ], 202);
             }
 
-            $this->Flash->success(__(
-                'Restore/import completed from {0}: {1} tables, {2} rows',
-                $sourceLabel,
-                $stats['table_count'],
-                $stats['row_count'],
-            ));
+            $this->Flash->success(__('Restore started. Progress will continue in the background.'));
+
+            return $this->redirect(['action' => 'index']);
         } catch (Exception $e) {
-            Log::error('Restore failed: ' . $e->getMessage());
+            Log::error('Restore failed to start: ' . $e->getMessage());
 
             if ($restoreTrackedBackup !== null) {
                 $restoreTrackedBackup->status = 'failed';
                 $restoreTrackedBackup->notes = __(
-                    'Restore failed at {0}: {1}',
+                    'Restore failed to start at {0}: {1}',
                     date('Y-m-d H:i:s'),
                     $e->getMessage(),
                 );
                 $this->Backups->save($restoreTrackedBackup);
             }
-            $restoreStatusService->markFailed(sprintf('Restore/import failed: %s', $e->getMessage()), [
+            $restoreStatusService->markFailed(sprintf('Restore/import failed to start: %s', $e->getMessage()), [
                 'source' => $sourceLabel,
                 'backup_id' => $id,
                 'actor' => $actor,
@@ -314,15 +275,32 @@ class BackupsController extends AppController
             if ($expectsJson) {
                 return $this->jsonResponse([
                     'success' => false,
-                    'message' => __('Restore failed: {0}', $e->getMessage()),
+                    'message' => __('Restore failed to start: {0}', $e->getMessage()),
                 ], 500);
             }
-            $this->Flash->error(__('Restore failed: {0}', $e->getMessage()));
-        } finally {
+            $this->Flash->error(__('Restore failed to start: {0}', $e->getMessage()));
             $restoreStatusService->releaseLock();
         }
 
         return $this->redirect(['action' => 'index']);
+    }
+
+    /**
+     * Launch staged restore runner without exposing the encryption key in process args.
+     */
+    private function launchRestoreRunner(string $token): void
+    {
+        $php = escapeshellarg(PHP_BINARY);
+        $cake = escapeshellarg(ROOT . DS . 'bin' . DS . 'cake');
+        $arg = escapeshellarg($token);
+
+        if (PHP_OS_FAMILY === 'Windows') {
+            pclose(popen("start /B {$php} {$cake} backup_restore_run {$arg}", 'r'));
+
+            return;
+        }
+
+        exec("nohup {$php} {$cake} backup_restore_run {$arg} > /dev/null 2>&1 &");
     }
 
     /**

--- a/app/src/Controller/BackupsController.php
+++ b/app/src/Controller/BackupsController.php
@@ -10,8 +10,9 @@ use App\Services\RestoreStatusService;
 use Cake\Http\Response;
 use Cake\I18n\DateTime;
 use Cake\Log\Log;
-use Exception;
 use Psr\Http\Message\UploadedFileInterface;
+use RuntimeException;
+use Throwable;
 
 /**
  * Manages database backups: list, create, restore, download, delete, settings.
@@ -188,11 +189,13 @@ class BackupsController extends AppController
             $identity,
             'getIdentifier',
         ) ? (string)$identity->getIdentifier() : null;
+        $restoreId = bin2hex(random_bytes(16));
         if (
             !$restoreStatusService->acquireLock([
             'source' => $sourceLabel,
             'backup_id' => $id,
             'actor' => $actor,
+            'restore_id' => $restoreId,
             'message' => sprintf('Restore starting from %s.', $sourceLabel),
             ])
         ) {
@@ -223,6 +226,7 @@ class BackupsController extends AppController
                 'source' => $sourceLabel,
                 'backup_id' => $id,
                 'actor' => $actor,
+                'restore_id' => $restoreId,
             ]);
 
             if ($restoreTrackedBackup !== null) {
@@ -235,13 +239,15 @@ class BackupsController extends AppController
                 'source' => $sourceLabel,
                 'backup_id' => $id,
                 'actor' => $actor,
+                'restore_id' => $restoreId,
             ]);
-            $this->launchRestoreRunner($token);
+            $this->launchRestoreRunner($token, $restoreId);
 
             $restoreStatusService->updateStatus('queued', sprintf('Restore queued from %s.', $sourceLabel), [
                 'source' => $sourceLabel,
                 'backup_id' => $id,
                 'actor' => $actor,
+                'restore_id' => $restoreId,
             ]);
 
             if ($expectsJson) {
@@ -255,7 +261,7 @@ class BackupsController extends AppController
             $this->Flash->success(__('Restore started. Progress will continue in the background.'));
 
             return $this->redirect(['action' => 'index']);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             Log::error('Restore failed to start: ' . $e->getMessage());
 
             if ($restoreTrackedBackup !== null) {
@@ -271,6 +277,7 @@ class BackupsController extends AppController
                 'source' => $sourceLabel,
                 'backup_id' => $id,
                 'actor' => $actor,
+                'restore_id' => $restoreId,
             ]);
             if ($expectsJson) {
                 return $this->jsonResponse([
@@ -288,19 +295,30 @@ class BackupsController extends AppController
     /**
      * Launch staged restore runner without exposing the encryption key in process args.
      */
-    private function launchRestoreRunner(string $token): void
+    private function launchRestoreRunner(string $token, string $restoreId): void
     {
         $php = escapeshellarg(PHP_BINARY);
         $cake = escapeshellarg(ROOT . DS . 'bin' . DS . 'cake');
         $arg = escapeshellarg($token);
+        $restoreArg = escapeshellarg($restoreId);
 
         if (PHP_OS_FAMILY === 'Windows') {
-            pclose(popen("start /B {$php} {$cake} backup_restore_run {$arg}", 'r'));
+            $process = popen("start /B {$php} {$cake} backup_restore_run {$arg} {$restoreArg}", 'r');
+            if ($process === false) {
+                throw new RuntimeException('Unable to launch restore runner process.');
+            }
+            $exitCode = pclose($process);
+            if ($exitCode !== 0) {
+                throw new RuntimeException('Restore runner process launch failed.');
+            }
 
             return;
         }
 
-        exec("nohup {$php} {$cake} backup_restore_run {$arg} > /dev/null 2>&1 &");
+        exec("nohup {$php} {$cake} backup_restore_run {$arg} {$restoreArg} > /dev/null 2>&1 &", $output, $exitCode);
+        if ($exitCode !== 0) {
+            throw new RuntimeException('Restore runner process launch failed.');
+        }
     }
 
     /**

--- a/app/src/Controller/BackupsController.php
+++ b/app/src/Controller/BackupsController.php
@@ -11,6 +11,7 @@ use App\Services\RestoreStatusService;
 use Cake\Http\Response;
 use Cake\I18n\DateTime;
 use Cake\Log\Log;
+use Exception;
 use Psr\Http\Message\UploadedFileInterface;
 use Throwable;
 

--- a/app/src/Middleware/RestoreMaintenanceMiddleware.php
+++ b/app/src/Middleware/RestoreMaintenanceMiddleware.php
@@ -15,6 +15,13 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 class RestoreMaintenanceMiddleware implements MiddlewareInterface
 {
+    /**
+     * Block normal request handling while a restore is active.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request Server request
+     * @param \Psr\Http\Server\RequestHandlerInterface $handler Request handler
+     * @return \Psr\Http\Message\ResponseInterface
+     */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $statusService = new RestoreStatusService();

--- a/app/src/Middleware/RestoreMaintenanceMiddleware.php
+++ b/app/src/Middleware/RestoreMaintenanceMiddleware.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Middleware;
+
+use App\Services\RestoreStatusService;
+use Cake\Http\Response;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Short-circuits normal web traffic while destructive database restore is running.
+ */
+class RestoreMaintenanceMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $statusService = new RestoreStatusService();
+        $status = $statusService->getStatus();
+        if (empty($status['locked']) && ($status['status'] ?? null) !== 'running') {
+            return $handler->handle($request);
+        }
+
+        $path = $request->getUri()->getPath();
+        if ($path === '/backups/status') {
+            return (new Response())
+                ->withType('application/json')
+                ->withStringBody((string)json_encode($status));
+        }
+
+        if ($path === '/health') {
+            return (new Response())
+                ->withStatus(503)
+                ->withType('application/json')
+                ->withStringBody((string)json_encode([
+                    'status' => 'restore_in_progress',
+                    'restore' => $status,
+                    'timestamp' => date('c'),
+                ]));
+        }
+
+        $accept = $request->getHeaderLine('Accept');
+        if (str_contains($accept, 'application/json')) {
+            return (new Response())
+                ->withStatus(503)
+                ->withType('application/json')
+                ->withStringBody((string)json_encode([
+                    'success' => false,
+                    'message' => 'Restore is in progress. Please try again after it completes.',
+                    'restore' => $status,
+                ]));
+        }
+
+        return (new Response())
+            ->withStatus(503)
+            ->withType('text/html')
+            ->withStringBody($this->htmlBody($status));
+    }
+
+    /**
+     * @param array<string, mixed> $status
+     */
+    private function htmlBody(array $status): string
+    {
+        $message = htmlspecialchars(
+            (string)($status['message'] ?? 'Restore is in progress.'),
+            ENT_QUOTES | ENT_SUBSTITUTE,
+            'UTF-8',
+        );
+
+        $style = 'body{font-family:system-ui,sans-serif;margin:3rem;line-height:1.5;color:#222}'
+            . '.card{max-width:42rem;padding:1.5rem;border:1px solid #ddd;border-radius:.5rem}';
+
+        return <<<HTML
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="refresh" content="10">
+    <title>Restore in progress</title>
+    <style>{$style}</style>
+</head>
+<body>
+    <main class="card">
+        <h1>Restore in progress</h1>
+        <p>{$message}</p>
+        <p>This page will refresh automatically.</p>
+    </main>
+</body>
+</html>
+HTML;
+    }
+}

--- a/app/src/Middleware/RestoreMaintenanceMiddleware.php
+++ b/app/src/Middleware/RestoreMaintenanceMiddleware.php
@@ -26,7 +26,8 @@ class RestoreMaintenanceMiddleware implements MiddlewareInterface
     {
         $statusService = new RestoreStatusService();
         $status = $statusService->getStatus();
-        if (empty($status['locked']) && ($status['status'] ?? null) !== 'running') {
+        $requiresMaintenance = !empty($status['maintenance_required']);
+        if (empty($status['locked']) && ($status['status'] ?? null) !== 'running' && !$requiresMaintenance) {
             return $handler->handle($request);
         }
 
@@ -51,17 +52,19 @@ class RestoreMaintenanceMiddleware implements MiddlewareInterface
         $accept = $request->getHeaderLine('Accept');
         if (str_contains($accept, 'application/json')) {
             return (new Response())
-                ->withStatus(503)
+                ->withStatus($requiresMaintenance ? 500 : 503)
                 ->withType('application/json')
                 ->withStringBody((string)json_encode([
                     'success' => false,
-                    'message' => 'Restore is in progress. Please try again after it completes.',
+                    'message' => $requiresMaintenance
+                        ? 'Restore failed and maintenance is required.'
+                        : 'Restore is in progress. Please try again after it completes.',
                     'restore' => $status,
                 ]));
         }
 
         return (new Response())
-            ->withStatus(503)
+            ->withStatus($requiresMaintenance ? 500 : 503)
             ->withType('text/html')
             ->withStringBody($this->htmlBody($status));
     }
@@ -76,9 +79,19 @@ class RestoreMaintenanceMiddleware implements MiddlewareInterface
             ENT_QUOTES | ENT_SUBSTITUTE,
             'UTF-8',
         );
+        $isFailed = ($status['status'] ?? null) === 'failed';
+        $title = $isFailed ? 'Restore failed' : 'Restore in progress';
+        $escapedTitle = htmlspecialchars($title, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        $logHtml = $this->logHtml($status);
 
         $style = 'body{font-family:system-ui,sans-serif;margin:3rem;line-height:1.5;color:#222}'
-            . '.card{max-width:42rem;padding:1.5rem;border:1px solid #ddd;border-radius:.5rem}';
+            . '.card{max-width:52rem;padding:1.5rem;border:1px solid #ddd;border-radius:.5rem}'
+            . '.log{max-height:24rem;overflow:auto;background:#111;color:#f5f5f5;padding:1rem;border-radius:.375rem}'
+            . '.log-entry{margin:0 0 .5rem}.log-time{color:#9ad;margin-right:.5rem}';
+        $refresh = $isFailed ? '' : '<meta http-equiv="refresh" content="10">';
+        $helpText = $isFailed
+            ? 'The restore did not complete. Review the log below before restarting the application.'
+            : 'This page will refresh automatically.';
 
         return <<<HTML
 <!doctype html>
@@ -86,18 +99,43 @@ class RestoreMaintenanceMiddleware implements MiddlewareInterface
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="refresh" content="10">
-    <title>Restore in progress</title>
+    {$refresh}
+    <title>{$escapedTitle}</title>
     <style>{$style}</style>
 </head>
 <body>
     <main class="card">
-        <h1>Restore in progress</h1>
+        <h1>{$escapedTitle}</h1>
         <p>{$message}</p>
-        <p>This page will refresh automatically.</p>
+        <p>{$helpText}</p>
+        {$logHtml}
     </main>
 </body>
 </html>
 HTML;
+    }
+
+    /**
+     * @param array<string, mixed> $status
+     */
+    private function logHtml(array $status): string
+    {
+        $log = $status['log'] ?? [];
+        if (!is_array($log) || $log === []) {
+            return '<p>No restore log entries have been written yet.</p>';
+        }
+
+        $entries = [];
+        foreach ($log as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+            $timestamp = htmlspecialchars((string)($entry['timestamp'] ?? ''), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            $message = htmlspecialchars((string)($entry['message'] ?? ''), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            $entries[] = "<p class=\"log-entry\"><span class=\"log-time\">{$timestamp}</span>{$message}</p>";
+        }
+
+        return '<section aria-labelledby="restore-log-title"><h2 id="restore-log-title">Restore log</h2>'
+            . '<div class="log" role="log" aria-live="polite">' . implode('', $entries) . '</div></section>';
     }
 }

--- a/app/src/Queue/Task/BackupRestoreTask.php
+++ b/app/src/Queue/Task/BackupRestoreTask.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Queue\Task;
+
+use App\Command\UpdateDatabaseCommand;
+use App\Services\BackupRestoreRunnerService;
+use Cake\Command\Command;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOutput;
+use Cake\Log\Log;
+use InvalidArgumentException;
+use Queue\Queue\Task;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Runs staged backup restores on the queue worker.
+ */
+class BackupRestoreTask extends Task
+{
+    public ?int $timeout = 3600;
+    public ?int $retries = 1;
+    public bool $unique = true;
+
+    /**
+     * @param array<string, mixed> $data Restore staging token and restore id
+     * @param int $jobId Queue job ID
+     */
+    public function run(array $data, int $jobId): void
+    {
+        $token = (string)($data['token'] ?? '');
+        $restoreId = (string)($data['restore_id'] ?? '');
+        if ($token === '' || $restoreId === '') {
+            throw new InvalidArgumentException('Missing restore token or restore id.');
+        }
+
+        try {
+            (new BackupRestoreRunnerService())->run(
+                $token,
+                $restoreId,
+                function (string $message): void {
+                    $this->io->out($message);
+                },
+                function (): void {
+                    $io = new ConsoleIo(new ConsoleOutput('php://stdout'), new ConsoleOutput('php://stderr'));
+                    $io->setInteractive(false);
+                    $exitCode = (new UpdateDatabaseCommand())->run([], $io);
+                    if ($exitCode !== null && $exitCode !== Command::CODE_SUCCESS) {
+                        throw new RuntimeException('Database migrations failed during restore.');
+                    }
+                },
+            );
+        } catch (Throwable $e) {
+            Log::error('Backup restore queue task failed: ' . $e->getMessage());
+
+            throw $e;
+        }
+    }
+}

--- a/app/src/Services/BackupRestoreRunnerService.php
+++ b/app/src/Services/BackupRestoreRunnerService.php
@@ -28,6 +28,7 @@ class BackupRestoreRunnerService
         $context = [
             'restore_id' => $restoreId,
         ];
+        $maintenanceRequired = false;
 
         try {
             if ($restoreStatusService->isLocked() && !$ownsRestoreLock) {
@@ -64,10 +65,19 @@ class BackupRestoreRunnerService
             $stats = (new BackupService())->import(
                 $staged['encrypted_data'],
                 $staged['encryption_key'],
-                function (array $progress) use ($restoreStatusService, $context, $log, &$lastPhase): void {
+                function (array $progress) use (
+                    $restoreStatusService,
+                    $context,
+                    $log,
+                    &$lastPhase,
+                    &$maintenanceRequired,
+                ): void {
                     $phase = (string)($progress['phase'] ?? 'running');
                     $message = (string)($progress['message'] ?? 'Restore in progress.');
                     unset($progress['phase'], $progress['message']);
+                    if (!in_array($phase, ['decrypting', 'decompressing', 'validating'], true)) {
+                        $maintenanceRequired = true;
+                    }
 
                     $restoreStatusService->updateStatus($phase, $message, array_merge($progress, $context));
                     if (
@@ -124,7 +134,7 @@ class BackupRestoreRunnerService
                 ));
                 $restoreStatusService->markFailed('Restore/import failed: ' . $e->getMessage(), array_merge(
                     $context,
-                    ['maintenance_required' => true],
+                    ['maintenance_required' => $maintenanceRequired],
                 ));
                 $this->appendLog($restoreStatusService, 'Restore failed: ' . $e->getMessage(), $log);
             }
@@ -144,7 +154,9 @@ class BackupRestoreRunnerService
     {
         $status = $restoreStatusService->getStatus();
 
-        return (string)($status['restore_id'] ?? '') === $restoreId;
+        return !empty($status['locked'])
+            && ($status['status'] ?? null) === 'running'
+            && (string)($status['restore_id'] ?? '') === $restoreId;
     }
 
     /**

--- a/app/src/Services/BackupRestoreRunnerService.php
+++ b/app/src/Services/BackupRestoreRunnerService.php
@@ -1,0 +1,220 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Services;
+
+use Cake\I18n\DateTime;
+use Cake\Log\Log;
+use Cake\ORM\TableRegistry;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Runs staged backup restores from worker or CLI entry points.
+ */
+class BackupRestoreRunnerService
+{
+    /**
+     * Consume a staged restore payload and execute the restore workflow.
+     *
+     * @param callable|null $log Callback receiving each user-visible restore log line.
+     * @param callable $migrationRunner Callback that runs post-schema-reset migrations.
+     * @return array{table_count: int, row_count: int}
+     */
+    public function run(string $token, string $restoreId, ?callable $log, callable $migrationRunner): array
+    {
+        $restoreStatusService = new RestoreStatusService();
+        $ownsRestoreLock = $restoreId !== '' && $this->restoreIdMatchesCurrentLock($restoreStatusService, $restoreId);
+        $context = [
+            'restore_id' => $restoreId,
+        ];
+
+        try {
+            if ($restoreStatusService->isLocked() && !$ownsRestoreLock) {
+                throw new RuntimeException('Restore lock belongs to a different restore operation.');
+            }
+
+            $stagingService = new RestoreStagingService();
+            $staged = $stagingService->consume($token);
+            $context = $staged['context'];
+            if ($restoreId !== '' && (string)($context['restore_id'] ?? '') !== $restoreId) {
+                throw new RuntimeException('Restore staging token does not match the active restore.');
+            }
+
+            if (!$restoreStatusService->isLocked()) {
+                if (
+                    !$restoreStatusService->acquireLock(array_merge($context, [
+                        'message' => 'Restore worker recovered missing restore lock.',
+                    ]))
+                ) {
+                    throw new RuntimeException('Unable to acquire restore lock for worker.');
+                }
+            }
+            $ownsRestoreLock = true;
+
+            $this->recordProgress(
+                $restoreStatusService,
+                'starting',
+                'Backup restore worker started.',
+                $context,
+                $log,
+            );
+
+            $lastPhase = null;
+            $stats = (new BackupService())->import(
+                $staged['encrypted_data'],
+                $staged['encryption_key'],
+                function (array $progress) use ($restoreStatusService, $context, $log, &$lastPhase): void {
+                    $phase = (string)($progress['phase'] ?? 'running');
+                    $message = (string)($progress['message'] ?? 'Restore in progress.');
+                    unset($progress['phase'], $progress['message']);
+
+                    $restoreStatusService->updateStatus($phase, $message, array_merge($progress, $context));
+                    if (
+                        $phase === 'table_restored'
+                        && isset($progress['tables_processed'], $progress['table_count'], $progress['rows_processed'])
+                    ) {
+                        $this->appendLog(
+                            $restoreStatusService,
+                            sprintf(
+                                'Progress: %d/%d tables, %s rows.',
+                                (int)$progress['tables_processed'],
+                                (int)$progress['table_count'],
+                                number_format((int)$progress['rows_processed']),
+                            ),
+                            $log,
+                        );
+
+                        return;
+                    }
+                    if ($phase !== $lastPhase) {
+                        $this->appendLog($restoreStatusService, $message, $log);
+                        $lastPhase = $phase;
+                    }
+                },
+                $migrationRunner,
+            );
+
+            $this->updateTrackedBackupStatus($context, 'completed', sprintf(
+                'Restore completed at %s: %d tables, %d rows.',
+                DateTime::now()->format('Y-m-d H:i:s'),
+                $stats['table_count'],
+                $stats['row_count'],
+            ), $stats);
+            $restoreStatusService->markCompleted(sprintf(
+                'Restore/import completed: %d tables, %d rows.',
+                $stats['table_count'],
+                $stats['row_count'],
+            ), array_merge($context, [
+                'table_count' => $stats['table_count'],
+                'tables_processed' => $stats['table_count'],
+                'row_count' => $stats['row_count'],
+                'rows_processed' => $stats['row_count'],
+            ]));
+            $this->appendLog($restoreStatusService, 'Restore completed successfully.', $log);
+            $stagingService->discard($token);
+
+            return $stats;
+        } catch (Throwable $e) {
+            if ($ownsRestoreLock) {
+                $this->updateTrackedBackupStatus($context, 'failed', sprintf(
+                    'Restore failed at %s: %s',
+                    DateTime::now()->format('Y-m-d H:i:s'),
+                    $e->getMessage(),
+                ));
+                $restoreStatusService->markFailed('Restore/import failed: ' . $e->getMessage(), array_merge(
+                    $context,
+                    ['maintenance_required' => true],
+                ));
+                $this->appendLog($restoreStatusService, 'Restore failed: ' . $e->getMessage(), $log);
+            }
+
+            throw $e;
+        } finally {
+            if ($ownsRestoreLock) {
+                $restoreStatusService->releaseLock();
+            }
+        }
+    }
+
+    /**
+     * Check whether the active lock belongs to this restore runner.
+     */
+    private function restoreIdMatchesCurrentLock(RestoreStatusService $restoreStatusService, string $restoreId): bool
+    {
+        $status = $restoreStatusService->getStatus();
+
+        return (string)($status['restore_id'] ?? '') === $restoreId;
+    }
+
+    /**
+     * Persist final async restore status to the tracked backup row when available.
+     *
+     * @param array<string, mixed> $context
+     * @param array{table_count: int, row_count: int}|null $stats
+     */
+    private function updateTrackedBackupStatus(
+        array $context,
+        string $status,
+        string $notes,
+        ?array $stats = null,
+    ): void {
+        $backupId = $context['backup_id'] ?? null;
+        if ($backupId === null || $backupId === '') {
+            return;
+        }
+
+        try {
+            $backups = TableRegistry::getTableLocator()->get('Backups');
+            $backup = $backups->find()->where(['id' => $backupId])->first();
+            if ($backup === null) {
+                $backup = $backups->newEntity([
+                    'id' => $backupId,
+                    'filename' => (string)($context['source'] ?? 'Restored backup'),
+                    'storage_type' => 'local',
+                ], ['accessibleFields' => [
+                    'id' => true,
+                    'filename' => true,
+                    'storage_type' => true,
+                ]]);
+            }
+
+            $backup->status = $status;
+            $backup->notes = $notes;
+            if ($stats !== null) {
+                $backup->table_count = $stats['table_count'];
+                $backup->row_count = $stats['row_count'];
+            }
+            $backups->saveOrFail($backup);
+        } catch (Throwable $e) {
+            Log::warning('Unable to update backup restore status row: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Record a phase update and append it to the visible restore log.
+     *
+     * @param array<string, mixed> $context
+     */
+    private function recordProgress(
+        RestoreStatusService $restoreStatusService,
+        string $phase,
+        string $message,
+        array $context,
+        ?callable $log,
+    ): void {
+        $restoreStatusService->updateStatus($phase, $message, $context);
+        $this->appendLog($restoreStatusService, $message, $log);
+    }
+
+    /**
+     * Append a bounded log line to restore status and the caller log.
+     */
+    private function appendLog(RestoreStatusService $restoreStatusService, string $message, ?callable $log): void
+    {
+        $restoreStatusService->appendLog($message);
+        if ($log !== null) {
+            $log($message);
+        }
+    }
+}

--- a/app/src/Services/BackupSchemaManifestService.php
+++ b/app/src/Services/BackupSchemaManifestService.php
@@ -12,11 +12,12 @@ class BackupSchemaManifestService
 {
     /**
      * @param array<int, string> $excludedTables
+     * @param string $connectionName CakePHP connection name to describe.
      * @return array<string, mixed>
      */
-    public function export(array $excludedTables = []): array
+    public function export(array $excludedTables = [], string $connectionName = 'default'): array
     {
-        $connection = ConnectionManager::get('default');
+        $connection = ConnectionManager::get($connectionName);
         $schemaCollection = $connection->getSchemaCollection();
         $tables = array_values(array_filter(
             $schemaCollection->listTables(),

--- a/app/src/Services/BackupSchemaManifestService.php
+++ b/app/src/Services/BackupSchemaManifestService.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Services;
+
+use Cake\Datasource\ConnectionManager;
+
+/**
+ * Builds a database-neutral schema manifest for backup payloads.
+ */
+class BackupSchemaManifestService
+{
+    /**
+     * @param array<int, string> $excludedTables
+     * @return array<string, mixed>
+     */
+    public function export(array $excludedTables = []): array
+    {
+        $connection = ConnectionManager::get('default');
+        $schemaCollection = $connection->getSchemaCollection();
+        $tables = array_values(array_filter(
+            $schemaCollection->listTables(),
+            fn(string $table): bool => !in_array($table, $excludedTables, true),
+        ));
+        sort($tables);
+
+        $manifestTables = [];
+        foreach ($tables as $tableName) {
+            $schema = $schemaCollection->describe($tableName);
+            $columns = [];
+            foreach ($schema->columns() as $column) {
+                $definition = $schema->getColumn($column) ?? [];
+                $definition['type'] = $schema->getColumnType($column) ?? ($definition['type'] ?? 'string');
+                $columns[$column] = $this->normalizeDefinition($definition);
+            }
+
+            $constraints = [];
+            foreach ($schema->constraints() as $constraintName) {
+                $constraints[$constraintName] = $this->normalizeDefinition(
+                    $schema->getConstraint($constraintName) ?? [],
+                );
+            }
+
+            $indexes = [];
+            if (method_exists($schema, 'indexes')) {
+                foreach ($schema->indexes() as $indexName) {
+                    $indexes[$indexName] = $this->normalizeDefinition($schema->getIndex($indexName) ?? []);
+                }
+            }
+
+            $manifestTables[$tableName] = [
+                'columns' => $columns,
+                'constraints' => $constraints,
+                'indexes' => $indexes,
+            ];
+        }
+
+        return [
+            'version' => 1,
+            'tables' => $manifestTables,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $definition
+     * @return array<string, mixed>
+     */
+    private function normalizeDefinition(array $definition): array
+    {
+        foreach ($definition as $key => $value) {
+            if (is_object($value) && method_exists($value, '__toString')) {
+                $definition[$key] = (string)$value;
+            }
+        }
+
+        return $definition;
+    }
+}

--- a/app/src/Services/BackupSchemaManifestService.php
+++ b/app/src/Services/BackupSchemaManifestService.php
@@ -42,7 +42,7 @@ class BackupSchemaManifestService
             }
 
             $indexes = [];
-            if (method_exists($schema, 'indexes')) {
+            if (method_exists($schema, 'indexes') && method_exists($schema, 'getIndex')) {
                 foreach ($schema->indexes() as $indexName) {
                     $indexes[$indexName] = $this->normalizeDefinition($schema->getIndex($indexName) ?? []);
                 }

--- a/app/src/Services/BackupService.php
+++ b/app/src/Services/BackupService.php
@@ -26,6 +26,7 @@ class BackupService
 {
     use LocatorAwareTrait;
 
+    private const FORMAT_VERSION = 2;
     private const CIPHER = 'aes-256-gcm';
     private const PBKDF2_ITERATIONS = 100000;
     private const PBKDF2_ALGO = 'sha256';
@@ -61,13 +62,15 @@ class BackupService
 
         sort($tables);
 
+        $schemaManifest = (new BackupSchemaManifestService())->export();
         $payload = [
             'meta' => [
-                'version' => 1,
+                'version' => self::FORMAT_VERSION,
                 'created_at' => DateTime::now()->toIso8601String(),
                 'table_count' => count($tables),
                 'tables' => $tables,
             ],
+            'schema' => $schemaManifest,
             'tables' => [],
         ];
 
@@ -133,8 +136,51 @@ class BackupService
      * @param string $encryptionKey User-provided encryption key
      * @return array{table_count: int, row_count: int} Import statistics
      */
-    public function import(string $encryptedData, string $encryptionKey, ?callable $progressReporter = null): array
-    {
+    public function import(
+        string $encryptedData,
+        string $encryptionKey,
+        ?callable $progressReporter = null,
+        ?callable $migrationRunner = null,
+    ): array {
+        $payload = $this->decodePayload($encryptedData, $encryptionKey, $progressReporter);
+
+        $this->reportProgress($progressReporter, 'resetting_schema', 'Resetting database schema to backup structure.');
+        (new DatabaseSchemaResetService())->reset($payload['schema'], $progressReporter);
+
+        $stats = $this->importPayloadRows($payload, $progressReporter);
+
+        if ($migrationRunner !== null) {
+            $this->reportProgress($progressReporter, 'migrating', 'Applying application migrations.');
+            $migrationRunner();
+            $this->clearApplicationCachesAfterRestore();
+            $this->reportProgress($progressReporter, 'migrated', 'Application migrations completed.', [
+                'table_count' => $stats['table_count'],
+                'tables_processed' => $stats['table_count'],
+                'row_count' => $stats['row_count'],
+                'rows_processed' => $stats['row_count'],
+            ]);
+        } else {
+            $this->clearApplicationCachesAfterRestore();
+            $this->reportProgress($progressReporter, 'completed', 'Restore transaction committed.', [
+                'table_count' => $stats['table_count'],
+                'tables_processed' => $stats['table_count'],
+                'row_count' => $stats['row_count'],
+                'rows_processed' => $stats['row_count'],
+            ]);
+        }
+
+        return $stats;
+    }
+
+    /**
+     * @param callable(array<string, mixed>):void|null $progressReporter
+     * @return array{meta: array<string, mixed>, schema: array<string, mixed>, tables: array<string, mixed>}
+     */
+    private function decodePayload(
+        string $encryptedData,
+        string $encryptionKey,
+        ?callable $progressReporter = null,
+    ): array {
         // Decrypt → decompress → JSON
         $this->reportProgress($progressReporter, 'decrypting', 'Decrypting backup file.');
         $compressed = $this->decrypt($encryptedData, $encryptionKey);
@@ -147,10 +193,30 @@ class BackupService
 
         $this->reportProgress($progressReporter, 'validating', 'Validating backup payload.');
         $payload = json_decode($json, true);
-        if (!is_array($payload) || !isset($payload['tables']) || !isset($payload['meta'])) {
+        if (!is_array($payload) || !isset($payload['meta']) || !is_array($payload['meta'])) {
+            throw new RuntimeException('Invalid backup file structure');
+        }
+        if (($payload['meta']['version'] ?? null) !== self::FORMAT_VERSION) {
+            throw new RuntimeException('Unsupported backup format. Regenerate the backup with this KMP release.');
+        }
+        if (
+            !isset($payload['tables'], $payload['schema'])
+            || !is_array($payload['schema'])
+            || !is_array($payload['tables'])
+        ) {
             throw new RuntimeException('Invalid backup file structure');
         }
 
+        return $payload;
+    }
+
+    /**
+     * @param array{tables: array<string, mixed>} $payload
+     * @param callable(array<string, mixed>):void|null $progressReporter
+     * @return array{table_count: int, row_count: int}
+     */
+    private function importPayloadRows(array $payload, ?callable $progressReporter = null): array
+    {
         $tablesToRestore = [];
         foreach ($payload['tables'] as $tableName => $rows) {
             if (in_array($tableName, self::EXCLUDED_TABLES, true)) {
@@ -413,10 +479,10 @@ class BackupService
             }
 
             $connection->commit();
-            $this->clearApplicationCachesAfterRestore();
-            $this->reportProgress($progressReporter, 'completed', 'Restore transaction committed.', [
+            $this->reportProgress($progressReporter, 'data_imported', 'Backup data import committed.', [
                 'table_count' => $tableCount,
                 'tables_processed' => $processedTables,
+                'row_count' => $totalRows,
                 'rows_processed' => $totalRows,
             ]);
         } catch (Exception $e) {

--- a/app/src/Services/BackupService.php
+++ b/app/src/Services/BackupService.php
@@ -9,23 +9,18 @@ use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Datasource\ConnectionManager;
 use Cake\I18n\DateTime;
 use Cake\Log\Log;
-use Cake\ORM\Locator\LocatorAwareTrait;
-use Cake\Utility\Inflector;
 use DateTimeImmutable;
-use Exception;
 use RuntimeException;
 use Throwable;
 
 /**
  * Database-agnostic backup and restore service.
  *
- * Exports all application tables via the ORM as JSON, compresses with gzip,
+ * Exports all application tables via direct database reads as JSON, compresses with gzip,
  * and encrypts with AES-256-GCM. Restore reverses the process.
  */
 class BackupService
 {
-    use LocatorAwareTrait;
-
     private const FORMAT_VERSION = 2;
     private const CIPHER = 'aes-256-gcm';
     private const PBKDF2_ITERATIONS = 100000;
@@ -35,13 +30,43 @@ class BackupService
     private const TAG_LENGTH = 16;
 
     /**
-     * Tables excluded from backup (transient or migration-tracking data).
+     * Tables excluded from backup because they contain transient runtime state.
+     *
+     * Queue state, backup metadata, and session tokens should not cross
+     * environments. Phinx migration logs are intentionally preserved so a
+     * restored database keeps accurate main/plugin migration history.
      */
     private const EXCLUDED_TABLES = [
         'queued_jobs',
         'queue_processes',
         'backups',
+        'sessions',
     ];
+
+    /**
+     * Runtime tables whose rows are excluded but schemas must be preserved.
+     */
+    private const OPERATIONAL_SCHEMA_TABLES = [
+        'backups',
+        'queued_jobs',
+        'queue_processes',
+        'sessions',
+    ];
+
+    /**
+     * @param string $connectionName CakePHP connection name to back up or restore.
+     */
+    public function __construct(private readonly string $connectionName = 'default')
+    {
+    }
+
+    /**
+     * Return true when the table should never appear in a backup payload.
+     */
+    private static function isExcludedTable(string $tableName): bool
+    {
+        return in_array($tableName, self::EXCLUDED_TABLES, true);
+    }
 
     /**
      * Export all application tables to an encrypted backup file.
@@ -51,18 +76,18 @@ class BackupService
      */
     public function export(string $encryptionKey): array
     {
-        $connection = ConnectionManager::get('default');
+        $connection = $this->connection();
         $schemaCollection = $connection->getSchemaCollection();
         $allTables = $schemaCollection->listTables();
 
-        // Filter out excluded tables (queue jobs are transient)
+        // Filter out transient tables while preserving migration history.
         $tables = array_values(array_filter($allTables, function (string $table) {
-            return !in_array($table, self::EXCLUDED_TABLES, true);
+            return !self::isExcludedTable($table);
         }));
 
         sort($tables);
 
-        $schemaManifest = (new BackupSchemaManifestService())->export(self::EXCLUDED_TABLES);
+        $schemaManifest = (new BackupSchemaManifestService())->export([], $this->connectionName);
         $payload = [
             'meta' => [
                 'version' => self::FORMAT_VERSION,
@@ -77,28 +102,9 @@ class BackupService
         $totalRows = 0;
 
         foreach ($tables as $tableName) {
-            try {
-                $tableObj = $this->fetchTable(
-                    ucfirst(Inflector::camelize($tableName)),
-                );
-            } catch (Exception $e) {
-                // Fallback: query directly
-                $tableObj = null;
-            }
-
-            $rows = [];
-            if ($tableObj !== null) {
-                // Include soft-deleted rows so backups are complete
-                $finder = $tableObj->hasBehavior('Trash') ? 'withTrashed' : 'all';
-                $query = $tableObj->find($finder)->disableHydration();
-                foreach ($query as $row) {
-                    $rows[] = $row;
-                }
-            } else {
-                // Direct query fallback for tables without a Table class
-                $stmt = $connection->execute("SELECT * FROM {$connection->getDriver()->quoteIdentifier($tableName)}");
-                $rows = $stmt->fetchAll('assoc') ?: [];
-            }
+            $quotedTable = $connection->getDriver()->quoteIdentifier($tableName);
+            $stmt = $connection->execute("SELECT * FROM {$quotedTable}");
+            $rows = $stmt->fetchAll('assoc') ?: [];
 
             $payload['tables'][$tableName] = $rows;
             $totalRows += count($rows);
@@ -145,6 +151,7 @@ class BackupService
         ?callable $migrationRunner = null,
     ): array {
         $payload = $this->decodePayload($encryptedData, $encryptionKey, $progressReporter);
+        $payload = $this->ensureOperationalSchemaTables($payload);
 
         $this->reportProgress($progressReporter, 'resetting_schema', 'Resetting database schema to backup structure.');
         (new DatabaseSchemaResetService())->reset($payload['schema'], $progressReporter);
@@ -172,6 +179,47 @@ class BackupService
         }
 
         return $stats;
+    }
+
+    /**
+     * Add operational table definitions that older backup manifests omitted.
+     *
+     * The rows remain excluded from the restore payload, but preserving table
+     * shapes keeps runtime services usable after schema reset.
+     *
+     * @param array{meta: array<string, mixed>, schema: array<string, mixed>, tables: array<string, mixed>} $payload
+     * @return array{meta: array<string, mixed>, schema: array<string, mixed>, tables: array<string, mixed>}
+     */
+    private function ensureOperationalSchemaTables(array $payload): array
+    {
+        $schemaTables = $payload['schema']['tables'] ?? [];
+        if (!is_array($schemaTables)) {
+            return $payload;
+        }
+
+        $missingTables = array_values(array_diff(self::OPERATIONAL_SCHEMA_TABLES, array_keys($schemaTables)));
+        if ($missingTables === []) {
+            return $payload;
+        }
+
+        $connection = $this->connection();
+        $currentTables = $connection->getSchemaCollection()->listTables();
+        $availableMissingTables = array_values(array_intersect($missingTables, $currentTables));
+        if ($availableMissingTables === []) {
+            return $payload;
+        }
+
+        $preservedSchema = (new BackupSchemaManifestService())->export(
+            array_values(array_diff($currentTables, $availableMissingTables)),
+            $this->connectionName,
+        );
+        foreach ($availableMissingTables as $tableName) {
+            if (isset($preservedSchema['tables'][$tableName])) {
+                $payload['schema']['tables'][$tableName] = $preservedSchema['tables'][$tableName];
+            }
+        }
+
+        return $payload;
     }
 
     /**
@@ -221,7 +269,7 @@ class BackupService
     {
         $tablesToRestore = [];
         foreach ($payload['tables'] as $tableName => $rows) {
-            if (in_array($tableName, self::EXCLUDED_TABLES, true)) {
+            if (self::isExcludedTable($tableName)) {
                 continue;
             }
             $tablesToRestore[$tableName] = is_array($rows) ? $rows : [];
@@ -234,7 +282,7 @@ class BackupService
             'rows_processed' => 0,
         ]);
 
-        $connection = ConnectionManager::get('default');
+        $connection = $this->connection();
         $schemaCollection = $connection->getSchemaCollection();
         $driver = $connection->getDriver();
         $isPostgres = $driver instanceof Postgres;
@@ -644,6 +692,14 @@ SQL;
         $maxRowsByParams = intdiv(60000, max(1, $columnCount));
 
         return max(1, min(200, $maxRowsByParams));
+    }
+
+    /**
+     * Return the configured backup target connection.
+     */
+    private function connection()
+    {
+        return ConnectionManager::get($this->connectionName);
     }
 
     /**

--- a/app/src/Services/BackupService.php
+++ b/app/src/Services/BackupService.php
@@ -10,6 +10,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\I18n\DateTime;
 use Cake\Log\Log;
 use DateTimeImmutable;
+use Exception;
 use RuntimeException;
 use Throwable;
 
@@ -154,7 +155,7 @@ class BackupService
         $payload = $this->ensureOperationalSchemaTables($payload);
 
         $this->reportProgress($progressReporter, 'resetting_schema', 'Resetting database schema to backup structure.');
-        (new DatabaseSchemaResetService())->reset($payload['schema'], $progressReporter);
+        (new DatabaseSchemaResetService($this->connectionName))->reset($payload['schema'], $progressReporter);
 
         $stats = $this->importPayloadRows($payload, $progressReporter);
 
@@ -255,6 +256,23 @@ class BackupService
             || !is_array($payload['tables'])
         ) {
             throw new RuntimeException('Invalid backup file structure');
+        }
+        if (
+            ($payload['schema']['version'] ?? null) !== 1
+            || !isset($payload['schema']['tables'])
+            || !is_array($payload['schema']['tables'])
+        ) {
+            throw new RuntimeException('Invalid backup file structure');
+        }
+        foreach ($payload['tables'] as $tableName => $rows) {
+            if (!is_string($tableName) || !is_array($rows) || !array_is_list($rows)) {
+                throw new RuntimeException('Invalid backup table payload structure');
+            }
+            foreach ($rows as $row) {
+                if (!is_array($row)) {
+                    throw new RuntimeException('Invalid backup table row structure');
+                }
+            }
         }
 
         return $payload;

--- a/app/src/Services/BackupService.php
+++ b/app/src/Services/BackupService.php
@@ -62,7 +62,7 @@ class BackupService
 
         sort($tables);
 
-        $schemaManifest = (new BackupSchemaManifestService())->export();
+        $schemaManifest = (new BackupSchemaManifestService())->export(self::EXCLUDED_TABLES);
         $payload = [
             'meta' => [
                 'version' => self::FORMAT_VERSION,
@@ -134,6 +134,8 @@ class BackupService
      *
      * @param string $encryptedData Raw encrypted backup bytes
      * @param string $encryptionKey User-provided encryption key
+     * @param callable(array<string, mixed>):void|null $progressReporter Restore progress callback
+     * @param callable():void|null $migrationRunner Post-import migration callback
      * @return array{table_count: int, row_count: int} Import statistics
      */
     public function import(

--- a/app/src/Services/DatabaseSchemaResetService.php
+++ b/app/src/Services/DatabaseSchemaResetService.php
@@ -1,0 +1,328 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Services;
+
+use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Postgres;
+use Cake\Datasource\ConnectionManager;
+use InvalidArgumentException;
+use PDO;
+use RuntimeException;
+
+/**
+ * Recreates the database schema from a backup schema manifest.
+ */
+class DatabaseSchemaResetService
+{
+    /**
+     * @param array<string, mixed> $manifest
+     * @param callable(array<string, mixed>):void|null $progressReporter
+     */
+    public function reset(array $manifest, ?callable $progressReporter = null): void
+    {
+        if (($manifest['version'] ?? null) !== 1 || !isset($manifest['tables']) || !is_array($manifest['tables'])) {
+            throw new InvalidArgumentException('Backup schema manifest is missing or unsupported.');
+        }
+
+        $connection = ConnectionManager::get('default');
+        $driver = $connection->getDriver();
+        if (!$driver instanceof Mysql && !$driver instanceof Postgres) {
+            throw new RuntimeException('Backup schema reset currently supports MySQL and PostgreSQL connections.');
+        }
+
+        $tables = $manifest['tables'];
+        $this->report($progressReporter, 'resetting_schema', 'Dropping current database tables.');
+        $this->dropExistingTables($connection, $driver);
+
+        $created = 0;
+        $tableCount = count($tables);
+        foreach ($tables as $tableName => $tableSpec) {
+            if (!is_string($tableName) || !is_array($tableSpec)) {
+                continue;
+            }
+
+            $this->report($progressReporter, 'creating_schema', sprintf(
+                'Creating table %s (%d/%d).',
+                $tableName,
+                $created + 1,
+                $tableCount,
+            ), [
+                'current_table' => $tableName,
+                'table_count' => $tableCount,
+                'tables_processed' => $created,
+            ]);
+            $connection->execute($this->createTableSql($driver, $tableName, $tableSpec));
+            $created++;
+        }
+
+        $this->createIndexes($connection, $driver, $tables);
+        $this->createForeignKeys($connection, $driver, $tables);
+    }
+
+    private function dropExistingTables($connection, Mysql|Postgres $driver): void
+    {
+        if ($driver instanceof Mysql) {
+            $database = $connection->config()['database'] ?? null;
+            $rows = $connection->execute(
+                'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_TYPE = ?',
+                [$database, 'BASE TABLE'],
+            )->fetchAll(PDO::FETCH_COLUMN) ?: [];
+            $connection->execute('SET FOREIGN_KEY_CHECKS = 0');
+            foreach ($rows as $table) {
+                $connection->execute('DROP TABLE IF EXISTS ' . $driver->quoteIdentifier((string)$table));
+            }
+            $connection->execute('SET FOREIGN_KEY_CHECKS = 1');
+
+            return;
+        }
+
+        $rows = $connection->execute(
+            "SELECT tablename FROM pg_tables WHERE schemaname = ANY(current_schemas(false))",
+        )->fetchAll(PDO::FETCH_COLUMN) ?: [];
+        foreach ($rows as $table) {
+            $connection->execute('DROP TABLE IF EXISTS ' . $driver->quoteIdentifier((string)$table) . ' CASCADE');
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $tableSpec
+     */
+    private function createTableSql(Mysql|Postgres $driver, string $tableName, array $tableSpec): string
+    {
+        $columns = $tableSpec['columns'] ?? [];
+        if (!is_array($columns) || $columns === []) {
+            throw new InvalidArgumentException("Backup schema table {$tableName} has no columns.");
+        }
+
+        $definitions = [];
+        foreach ($columns as $columnName => $definition) {
+            if (!is_string($columnName) || !is_array($definition)) {
+                continue;
+            }
+            $definitions[] = $this->columnSql($driver, $columnName, $definition);
+        }
+
+        foreach (($tableSpec['constraints'] ?? []) as $constraint) {
+            if (!is_array($constraint) || ($constraint['type'] ?? null) !== 'primary') {
+                continue;
+            }
+            $constraintColumns = $this->columnsSql($driver, (array)($constraint['columns'] ?? []));
+            if ($constraintColumns !== '') {
+                $definitions[] = 'PRIMARY KEY (' . $constraintColumns . ')';
+            }
+        }
+
+        return sprintf(
+            'CREATE TABLE %s (%s)',
+            $driver->quoteIdentifier($tableName),
+            implode(', ', $definitions),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $definition
+     */
+    private function columnSql(Mysql|Postgres $driver, string $columnName, array $definition): string
+    {
+        $type = (string)($definition['type'] ?? 'string');
+        $autoIncrement = (bool)($definition['autoIncrement'] ?? $definition['auto_increment'] ?? false);
+        $sql = $driver->quoteIdentifier($columnName)
+            . ' '
+            . $this->columnTypeSql($driver, $type, $definition, $autoIncrement);
+
+        if ($autoIncrement && $driver instanceof Mysql) {
+            $sql .= ' AUTO_INCREMENT';
+        }
+
+        if (!($definition['null'] ?? true)) {
+            $sql .= ' NOT NULL';
+        }
+
+        if (!$autoIncrement && array_key_exists('default', $definition) && $definition['default'] !== null) {
+            $sql .= ' DEFAULT ' . $this->defaultSql($driver, $definition['default'], $type);
+        }
+
+        return $sql;
+    }
+
+    /**
+     * @param array<string, mixed> $definition
+     */
+    private function columnTypeSql(
+        Mysql|Postgres $driver,
+        string $type,
+        array $definition,
+        bool $autoIncrement,
+    ): string {
+        if ($autoIncrement && $driver instanceof Postgres) {
+            return $type === 'biginteger' ? 'BIGSERIAL' : 'SERIAL';
+        }
+
+        $limit = isset($definition['length'])
+            ? (int)$definition['length']
+            : (isset($definition['limit']) ? (int)$definition['limit'] : null);
+
+        return match ($type) {
+            'biginteger' => 'BIGINT',
+            'tinyinteger' => $driver instanceof Mysql ? 'TINYINT' : 'SMALLINT',
+            'integer' => $limit !== null && $limit > 0 && $driver instanceof Mysql ? "INT({$limit})" : 'INTEGER',
+            'boolean' => $driver instanceof Mysql ? 'TINYINT(1)' : 'BOOLEAN',
+            'string' => 'VARCHAR(' . max(1, $limit ?? 255) . ')',
+            'text' => 'TEXT',
+            'date' => 'DATE',
+            'time' => 'TIME',
+            'datetime', 'timestamp' => $driver instanceof Mysql ? 'DATETIME' : 'TIMESTAMP',
+            'float' => $driver instanceof Mysql ? 'DOUBLE' : 'DOUBLE PRECISION',
+            'decimal' => $this->decimalTypeSql($definition),
+            'json' => $driver instanceof Mysql ? 'JSON' : 'JSONB',
+            default => throw new RuntimeException("Unsupported backup schema column type: {$type}"),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $definition
+     */
+    private function decimalTypeSql(array $definition): string
+    {
+        $precision = (int)($definition['precision'] ?? $definition['length'] ?? $definition['limit'] ?? 10);
+        $scale = (int)($definition['scale'] ?? 0);
+
+        return sprintf('DECIMAL(%d,%d)', max(1, $precision), max(0, $scale));
+    }
+
+    private function defaultSql(Mysql|Postgres $driver, mixed $default, string $type): string
+    {
+        if (is_bool($default)) {
+            return $driver instanceof Mysql ? ($default ? '1' : '0') : ($default ? 'TRUE' : 'FALSE');
+        }
+        if (is_int($default) || is_float($default)) {
+            return (string)$default;
+        }
+        if (is_string($default) && strtoupper($default) === 'CURRENT_TIMESTAMP') {
+            return 'CURRENT_TIMESTAMP';
+        }
+
+        return "'" . str_replace("'", "''", (string)$default) . "'";
+    }
+
+    /**
+     * @param array<string, mixed> $tables
+     */
+    private function createIndexes($connection, Mysql|Postgres $driver, array $tables): void
+    {
+        foreach ($tables as $tableName => $tableSpec) {
+            if (!is_string($tableName) || !is_array($tableSpec)) {
+                continue;
+            }
+            foreach (($tableSpec['constraints'] ?? []) as $constraintName => $constraint) {
+                if (
+                    !is_string($constraintName)
+                    || !is_array($constraint)
+                    || ($constraint['type'] ?? null) !== 'unique'
+                ) {
+                    continue;
+                }
+                $columnsSql = $this->columnsSql($driver, (array)($constraint['columns'] ?? []));
+                if ($columnsSql === '') {
+                    continue;
+                }
+                $connection->execute(sprintf(
+                    'CREATE UNIQUE INDEX %s ON %s (%s)',
+                    $driver->quoteIdentifier($constraintName),
+                    $driver->quoteIdentifier($tableName),
+                    $columnsSql,
+                ));
+            }
+            foreach (($tableSpec['indexes'] ?? []) as $indexName => $index) {
+                if (!is_string($indexName) || !is_array($index)) {
+                    continue;
+                }
+                $columnsSql = $this->columnsSql($driver, (array)($index['columns'] ?? []));
+                if ($columnsSql === '') {
+                    continue;
+                }
+                $unique = ($index['type'] ?? '') === 'unique' ? 'UNIQUE ' : '';
+                $connection->execute(sprintf(
+                    'CREATE %sINDEX %s ON %s (%s)',
+                    $unique,
+                    $driver->quoteIdentifier($indexName),
+                    $driver->quoteIdentifier($tableName),
+                    $columnsSql,
+                ));
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $tables
+     */
+    private function createForeignKeys($connection, Mysql|Postgres $driver, array $tables): void
+    {
+        foreach ($tables as $tableName => $tableSpec) {
+            if (!is_string($tableName) || !is_array($tableSpec)) {
+                continue;
+            }
+            foreach (($tableSpec['constraints'] ?? []) as $constraintName => $constraint) {
+                if (
+                    !is_string($constraintName)
+                    || !is_array($constraint)
+                    || ($constraint['type'] ?? null) !== 'foreign'
+                ) {
+                    continue;
+                }
+                $columnsSql = $this->columnsSql($driver, (array)($constraint['columns'] ?? []));
+                $references = (array)($constraint['references'] ?? []);
+                $referencedTable = $references[0] ?? null;
+                $referencedColumns = $references[1] ?? [];
+                $referencedColumnsSql = $this->columnsSql($driver, (array)$referencedColumns);
+                if (!is_string($referencedTable) || $columnsSql === '' || $referencedColumnsSql === '') {
+                    continue;
+                }
+
+                $sql = sprintf(
+                    'ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s)',
+                    $driver->quoteIdentifier($tableName),
+                    $driver->quoteIdentifier($constraintName),
+                    $columnsSql,
+                    $driver->quoteIdentifier($referencedTable),
+                    $referencedColumnsSql,
+                );
+                if (!empty($constraint['delete'])) {
+                    $sql .= ' ON DELETE ' . strtoupper((string)$constraint['delete']);
+                }
+                if (!empty($constraint['update'])) {
+                    $sql .= ' ON UPDATE ' . strtoupper((string)$constraint['update']);
+                }
+                $connection->execute($sql);
+            }
+        }
+    }
+
+    /**
+     * @param array<int, string> $columns
+     */
+    private function columnsSql(Mysql|Postgres $driver, array $columns): string
+    {
+        return implode(', ', array_map(
+            fn(string $column): string => $driver->quoteIdentifier($column),
+            array_values(array_filter($columns, 'is_string')),
+        ));
+    }
+
+    /**
+     * @param callable(array<string, mixed>):void|null $progressReporter
+     * @param array<string, mixed> $context
+     */
+    private function report(?callable $progressReporter, string $phase, string $message, array $context = []): void
+    {
+        if ($progressReporter === null) {
+            return;
+        }
+
+        $progressReporter(array_merge($context, [
+            'phase' => $phase,
+            'message' => $message,
+        ]));
+    }
+}

--- a/app/src/Services/DatabaseSchemaResetService.php
+++ b/app/src/Services/DatabaseSchemaResetService.php
@@ -32,32 +32,57 @@ class DatabaseSchemaResetService
         }
 
         $tables = $manifest['tables'];
+        $plan = $this->buildResetPlan($driver, $tables);
         $this->report($progressReporter, 'resetting_schema', 'Dropping current database tables.');
         $this->dropExistingTables($connection, $driver);
 
         $created = 0;
-        $tableCount = count($tables);
+        $tableCount = count($plan['tables']);
+        foreach ($plan['tables'] as $tablePlan) {
+            $this->report($progressReporter, 'creating_schema', sprintf(
+                'Creating table %s (%d/%d).',
+                $tablePlan['name'],
+                $created + 1,
+                $tableCount,
+            ), [
+                'current_table' => $tablePlan['name'],
+                'table_count' => $tableCount,
+                'tables_processed' => $created,
+            ]);
+            $connection->execute($tablePlan['sql']);
+            $created++;
+        }
+
+        foreach ($plan['indexes'] as $sql) {
+            $connection->execute($sql);
+        }
+        foreach ($plan['foreignKeys'] as $sql) {
+            $connection->execute($sql);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $tables
+     * @return array<string, array<int, mixed>>
+     */
+    private function buildResetPlan(Mysql|Postgres $driver, array $tables): array
+    {
+        $tableSql = [];
         foreach ($tables as $tableName => $tableSpec) {
             if (!is_string($tableName) || !is_array($tableSpec)) {
                 continue;
             }
-
-            $this->report($progressReporter, 'creating_schema', sprintf(
-                'Creating table %s (%d/%d).',
-                $tableName,
-                $created + 1,
-                $tableCount,
-            ), [
-                'current_table' => $tableName,
-                'table_count' => $tableCount,
-                'tables_processed' => $created,
-            ]);
-            $connection->execute($this->createTableSql($driver, $tableName, $tableSpec));
-            $created++;
+            $tableSql[] = [
+                'name' => $tableName,
+                'sql' => $this->createTableSql($driver, $tableName, $tableSpec),
+            ];
         }
 
-        $this->createIndexes($connection, $driver, $tables);
-        $this->createForeignKeys($connection, $driver, $tables);
+        return [
+            'tables' => $tableSql,
+            'indexes' => $this->indexSql($driver, $tables),
+            'foreignKeys' => $this->foreignKeySql($driver, $tables),
+        ];
     }
 
     private function dropExistingTables($connection, Mysql|Postgres $driver): void
@@ -69,10 +94,13 @@ class DatabaseSchemaResetService
                 [$database, 'BASE TABLE'],
             )->fetchAll(PDO::FETCH_COLUMN) ?: [];
             $connection->execute('SET FOREIGN_KEY_CHECKS = 0');
-            foreach ($rows as $table) {
-                $connection->execute('DROP TABLE IF EXISTS ' . $driver->quoteIdentifier((string)$table));
+            try {
+                foreach ($rows as $table) {
+                    $connection->execute('DROP TABLE IF EXISTS ' . $driver->quoteIdentifier((string)$table));
+                }
+            } finally {
+                $connection->execute('SET FOREIGN_KEY_CHECKS = 1');
             }
-            $connection->execute('SET FOREIGN_KEY_CHECKS = 1');
 
             return;
         }
@@ -208,9 +236,11 @@ class DatabaseSchemaResetService
 
     /**
      * @param array<string, mixed> $tables
+     * @return array<int, string>
      */
-    private function createIndexes($connection, Mysql|Postgres $driver, array $tables): void
+    private function indexSql(Mysql|Postgres $driver, array $tables): array
     {
+        $sql = [];
         foreach ($tables as $tableName => $tableSpec) {
             if (!is_string($tableName) || !is_array($tableSpec)) {
                 continue;
@@ -227,12 +257,12 @@ class DatabaseSchemaResetService
                 if ($columnsSql === '') {
                     continue;
                 }
-                $connection->execute(sprintf(
+                $sql[] = sprintf(
                     'CREATE UNIQUE INDEX %s ON %s (%s)',
                     $driver->quoteIdentifier($constraintName),
                     $driver->quoteIdentifier($tableName),
                     $columnsSql,
-                ));
+                );
             }
             foreach (($tableSpec['indexes'] ?? []) as $indexName => $index) {
                 if (!is_string($indexName) || !is_array($index)) {
@@ -243,22 +273,26 @@ class DatabaseSchemaResetService
                     continue;
                 }
                 $unique = ($index['type'] ?? '') === 'unique' ? 'UNIQUE ' : '';
-                $connection->execute(sprintf(
+                $sql[] = sprintf(
                     'CREATE %sINDEX %s ON %s (%s)',
                     $unique,
                     $driver->quoteIdentifier($indexName),
                     $driver->quoteIdentifier($tableName),
                     $columnsSql,
-                ));
+                );
             }
         }
+
+        return $sql;
     }
 
     /**
      * @param array<string, mixed> $tables
+     * @return array<int, string>
      */
-    private function createForeignKeys($connection, Mysql|Postgres $driver, array $tables): void
+    private function foreignKeySql(Mysql|Postgres $driver, array $tables): array
     {
+        $sql = [];
         foreach ($tables as $tableName => $tableSpec) {
             if (!is_string($tableName) || !is_array($tableSpec)) {
                 continue;
@@ -280,7 +314,7 @@ class DatabaseSchemaResetService
                     continue;
                 }
 
-                $sql = sprintf(
+                $foreignKeySql = sprintf(
                     'ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s)',
                     $driver->quoteIdentifier($tableName),
                     $driver->quoteIdentifier($constraintName),
@@ -289,14 +323,30 @@ class DatabaseSchemaResetService
                     $referencedColumnsSql,
                 );
                 if (!empty($constraint['delete'])) {
-                    $sql .= ' ON DELETE ' . strtoupper((string)$constraint['delete']);
+                    $foreignKeySql .= ' ON DELETE ' . $this->referentialActionSql($constraint['delete']);
                 }
                 if (!empty($constraint['update'])) {
-                    $sql .= ' ON UPDATE ' . strtoupper((string)$constraint['update']);
+                    $foreignKeySql .= ' ON UPDATE ' . $this->referentialActionSql($constraint['update']);
                 }
-                $connection->execute($sql);
+                $sql[] = $foreignKeySql;
             }
         }
+
+        return $sql;
+    }
+
+    /**
+     * Validate and normalize a foreign key referential action.
+     */
+    private function referentialActionSql(mixed $action): string
+    {
+        $normalized = strtoupper(trim(preg_replace('/\s+/', ' ', (string)$action) ?? ''));
+        $allowed = ['CASCADE', 'SET NULL', 'SET DEFAULT', 'RESTRICT', 'NO ACTION'];
+        if (!in_array($normalized, $allowed, true)) {
+            throw new InvalidArgumentException("Unsupported foreign key referential action: {$normalized}");
+        }
+
+        return $normalized;
     }
 
     /**

--- a/app/src/Services/DatabaseSchemaResetService.php
+++ b/app/src/Services/DatabaseSchemaResetService.php
@@ -15,6 +15,10 @@ use RuntimeException;
  */
 class DatabaseSchemaResetService
 {
+    public function __construct(private readonly string $connectionName = 'default')
+    {
+    }
+
     /**
      * @param array<string, mixed> $manifest
      * @param callable(array<string, mixed>):void|null $progressReporter
@@ -25,7 +29,7 @@ class DatabaseSchemaResetService
             throw new InvalidArgumentException('Backup schema manifest is missing or unsupported.');
         }
 
-        $connection = ConnectionManager::get('default');
+        $connection = ConnectionManager::get($this->connectionName);
         $driver = $connection->getDriver();
         if (!$driver instanceof Mysql && !$driver instanceof Postgres) {
             throw new RuntimeException('Backup schema reset currently supports MySQL and PostgreSQL connections.');
@@ -70,12 +74,15 @@ class DatabaseSchemaResetService
         $tableSql = [];
         foreach ($tables as $tableName => $tableSpec) {
             if (!is_string($tableName) || !is_array($tableSpec)) {
-                continue;
+                throw new InvalidArgumentException('Backup schema manifest contains an invalid table entry.');
             }
             $tableSql[] = [
                 'name' => $tableName,
                 'sql' => $this->createTableSql($driver, $tableName, $tableSpec),
             ];
+        }
+        if ($tableSql === []) {
+            throw new InvalidArgumentException('Backup schema manifest contains no restorable tables.');
         }
 
         return [
@@ -126,9 +133,12 @@ class DatabaseSchemaResetService
         $definitions = [];
         foreach ($columns as $columnName => $definition) {
             if (!is_string($columnName) || !is_array($definition)) {
-                continue;
+                throw new InvalidArgumentException("Backup schema table {$tableName} has an invalid column.");
             }
             $definitions[] = $this->columnSql($driver, $columnName, $definition);
+        }
+        if ($definitions === []) {
+            throw new InvalidArgumentException("Backup schema table {$tableName} has no restorable columns.");
         }
 
         foreach (($tableSpec['constraints'] ?? []) as $constraint) {

--- a/app/src/Services/DatabaseSchemaResetService.php
+++ b/app/src/Services/DatabaseSchemaResetService.php
@@ -193,6 +193,7 @@ class DatabaseSchemaResetService
 
         return match ($type) {
             'biginteger' => 'BIGINT',
+            'smallinteger' => 'SMALLINT',
             'tinyinteger' => $driver instanceof Mysql ? 'TINYINT' : 'SMALLINT',
             'integer' => $limit !== null && $limit > 0 && $driver instanceof Mysql ? "INT({$limit})" : 'INTEGER',
             'boolean' => $driver instanceof Mysql ? 'TINYINT(1)' : 'BOOLEAN',
@@ -200,6 +201,8 @@ class DatabaseSchemaResetService
             'text' => 'TEXT',
             'date' => 'DATE',
             'time' => 'TIME',
+            'timefractional' => 'TIME(6)',
+            'timestampfractional', 'datetimefractional' => $driver instanceof Mysql ? 'DATETIME(6)' : 'TIMESTAMP(6)',
             'datetime', 'timestamp' => $driver instanceof Mysql ? 'DATETIME' : 'TIMESTAMP',
             'float' => $driver instanceof Mysql ? 'DOUBLE' : 'DOUBLE PRECISION',
             'decimal' => $this->decimalTypeSql($definition),
@@ -223,6 +226,15 @@ class DatabaseSchemaResetService
     {
         if (is_bool($default)) {
             return $driver instanceof Mysql ? ($default ? '1' : '0') : ($default ? 'TRUE' : 'FALSE');
+        }
+        if ($driver instanceof Postgres && $type === 'boolean') {
+            $normalized = strtolower(trim((string)$default, "'\""));
+            if (in_array($normalized, ['1', 'true', 't', 'yes', 'y', 'on'], true)) {
+                return 'TRUE';
+            }
+            if (in_array($normalized, ['0', 'false', 'f', 'no', 'n', 'off'], true)) {
+                return 'FALSE';
+            }
         }
         if (is_int($default) || is_float($default)) {
             return (string)$default;
@@ -341,6 +353,12 @@ class DatabaseSchemaResetService
     private function referentialActionSql(mixed $action): string
     {
         $normalized = strtoupper(trim(preg_replace('/\s+/', ' ', (string)$action) ?? ''));
+        $normalized = match ($normalized) {
+            'NOACTION' => 'NO ACTION',
+            'SETNULL' => 'SET NULL',
+            'SETDEFAULT' => 'SET DEFAULT',
+            default => $normalized,
+        };
         $allowed = ['CASCADE', 'SET NULL', 'SET DEFAULT', 'RESTRICT', 'NO ACTION'];
         if (!in_array($normalized, $allowed, true)) {
             throw new InvalidArgumentException("Unsupported foreign key referential action: {$normalized}");

--- a/app/src/Services/RestoreStagingService.php
+++ b/app/src/Services/RestoreStagingService.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use Cake\Utility\Security;
 use RuntimeException;
 
 /**
@@ -12,6 +13,9 @@ class RestoreStagingService
 {
     private string $directory;
 
+    /**
+     * Initialize the restore staging directory.
+     */
     public function __construct(?string $directory = null)
     {
         $this->directory = $directory ?? sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'kmp_restore_staging';
@@ -21,12 +25,17 @@ class RestoreStagingService
         @chmod($this->directory, 0700);
     }
 
+    /**
+     * Stage encrypted restore payload bytes and return a single-use token.
+     *
+     * @param array<string, mixed> $context
+     */
     public function stage(string $encryptedData, string $encryptionKey, array $context = []): string
     {
         $token = bin2hex(random_bytes(24));
         $payload = json_encode([
             'encrypted_data' => base64_encode($encryptedData),
-            'encryption_key' => $encryptionKey,
+            'encrypted_key' => base64_encode(Security::encrypt($encryptionKey, $this->stagingEncryptionKey())),
             'context' => $context,
             'created_at' => date('c'),
         ], JSON_UNESCAPED_SLASHES);
@@ -49,14 +58,18 @@ class RestoreStagingService
     public function consume(string $token): array
     {
         $path = $this->path($token);
-        $json = is_file($path) ? file_get_contents($path) : false;
+        $claimedPath = $path . '.' . bin2hex(random_bytes(4)) . '.claimed';
+        if (!@rename($path, $claimedPath)) {
+            throw new RuntimeException('Restore staging payload not found.');
+        }
+
+        $json = file_get_contents($claimedPath);
         if ($json === false) {
             throw new RuntimeException('Restore staging payload not found.');
         }
-        @unlink($path);
 
         $payload = json_decode($json, true);
-        if (!is_array($payload) || !isset($payload['encrypted_data'], $payload['encryption_key'])) {
+        if (!is_array($payload) || !isset($payload['encrypted_data'], $payload['encrypted_key'])) {
             throw new RuntimeException('Restore staging payload is invalid.');
         }
 
@@ -64,14 +77,27 @@ class RestoreStagingService
         if ($encryptedData === false) {
             throw new RuntimeException('Restore staging payload data is invalid.');
         }
+        $encryptedKey = base64_decode((string)$payload['encrypted_key'], true);
+        if ($encryptedKey === false) {
+            throw new RuntimeException('Restore staging payload key is invalid.');
+        }
+        $encryptionKey = Security::decrypt($encryptedKey, $this->stagingEncryptionKey());
+        if ($encryptionKey === null) {
+            throw new RuntimeException('Restore staging payload key is invalid.');
+        }
+
+        @unlink($claimedPath);
 
         return [
             'encrypted_data' => $encryptedData,
-            'encryption_key' => (string)$payload['encryption_key'],
+            'encryption_key' => $encryptionKey,
             'context' => is_array($payload['context'] ?? null) ? $payload['context'] : [],
         ];
     }
 
+    /**
+     * Build the staged payload file path for a token.
+     */
     private function path(string $token): string
     {
         if (!preg_match('/^[a-f0-9]{48}$/', $token)) {
@@ -79,5 +105,19 @@ class RestoreStagingService
         }
 
         return $this->directory . DIRECTORY_SEPARATOR . $token . '.json';
+    }
+
+    /**
+     * Resolve the local staging encryption key.
+     */
+    private function stagingEncryptionKey(): string
+    {
+        $configuredKey = getenv('RESTORE_STAGING_KEY');
+        $key = $configuredKey === false ? Security::getSalt() : (string)$configuredKey;
+        if (strlen($key) < 32) {
+            $key = str_pad($key, 32, '0');
+        }
+
+        return $key;
     }
 }

--- a/app/src/Services/RestoreStagingService.php
+++ b/app/src/Services/RestoreStagingService.php
@@ -18,7 +18,7 @@ class RestoreStagingService
      */
     public function __construct(?string $directory = null)
     {
-        $this->directory = $directory ?? sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'kmp_restore_staging';
+        $this->directory = $directory ?? $this->defaultDirectory();
         if (!is_dir($this->directory) && !mkdir($this->directory, 0700, true) && !is_dir($this->directory)) {
             throw new RuntimeException("Cannot create restore staging directory: {$this->directory}");
         }
@@ -58,8 +58,8 @@ class RestoreStagingService
     public function consume(string $token): array
     {
         $path = $this->path($token);
-        $claimedPath = $path . '.' . bin2hex(random_bytes(4)) . '.claimed';
-        if (!@rename($path, $claimedPath)) {
+        $claimedPath = $this->claimPath($path);
+        if ($claimedPath === null) {
             throw new RuntimeException('Restore staging payload not found.');
         }
 
@@ -86,13 +86,23 @@ class RestoreStagingService
             throw new RuntimeException('Restore staging payload key is invalid.');
         }
 
-        @unlink($claimedPath);
-
         return [
             'encrypted_data' => $encryptedData,
             'encryption_key' => $encryptionKey,
             'context' => is_array($payload['context'] ?? null) ? $payload['context'] : [],
         ];
+    }
+
+    /**
+     * Delete a staged payload after the restore completes successfully.
+     */
+    public function discard(string $token): void
+    {
+        $path = $this->path($token);
+        @unlink($path);
+        foreach (glob($path . '.*.claimed') ?: [] as $claimedPath) {
+            @unlink($claimedPath);
+        }
     }
 
     /**
@@ -105,6 +115,34 @@ class RestoreStagingService
         }
 
         return $this->directory . DIRECTORY_SEPARATOR . $token . '.json';
+    }
+
+    /**
+     * Claim or reuse a previously claimed staging payload.
+     */
+    private function claimPath(string $path): ?string
+    {
+        $claimedPath = $path . '.' . bin2hex(random_bytes(4)) . '.claimed';
+        if (@rename($path, $claimedPath)) {
+            return $claimedPath;
+        }
+
+        $claimedPaths = glob($path . '.*.claimed') ?: [];
+
+        return $claimedPaths[0] ?? null;
+    }
+
+    /**
+     * Resolve the shared staging directory used by web and worker containers.
+     */
+    private function defaultDirectory(): string
+    {
+        $configuredDirectory = getenv('RESTORE_STAGING_DIR');
+        if (is_string($configuredDirectory) && $configuredDirectory !== '') {
+            return $configuredDirectory;
+        }
+
+        return TMP . 'restore_staging';
     }
 
     /**

--- a/app/src/Services/RestoreStagingService.php
+++ b/app/src/Services/RestoreStagingService.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Services;
+
+use RuntimeException;
+
+/**
+ * Stores web-initiated restore payloads outside the database for CLI pickup.
+ */
+class RestoreStagingService
+{
+    private string $directory;
+
+    public function __construct(?string $directory = null)
+    {
+        $this->directory = $directory ?? sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'kmp_restore_staging';
+        if (!is_dir($this->directory) && !mkdir($this->directory, 0700, true) && !is_dir($this->directory)) {
+            throw new RuntimeException("Cannot create restore staging directory: {$this->directory}");
+        }
+        @chmod($this->directory, 0700);
+    }
+
+    public function stage(string $encryptedData, string $encryptionKey, array $context = []): string
+    {
+        $token = bin2hex(random_bytes(24));
+        $payload = json_encode([
+            'encrypted_data' => base64_encode($encryptedData),
+            'encryption_key' => $encryptionKey,
+            'context' => $context,
+            'created_at' => date('c'),
+        ], JSON_UNESCAPED_SLASHES);
+        if ($payload === false) {
+            throw new RuntimeException('Failed to encode restore staging payload.');
+        }
+
+        $path = $this->path($token);
+        if (file_put_contents($path, $payload, LOCK_EX) === false) {
+            throw new RuntimeException('Failed to write restore staging payload.');
+        }
+        @chmod($path, 0600);
+
+        return $token;
+    }
+
+    /**
+     * @return array{encrypted_data: string, encryption_key: string, context: array<string, mixed>}
+     */
+    public function consume(string $token): array
+    {
+        $path = $this->path($token);
+        $json = is_file($path) ? file_get_contents($path) : false;
+        if ($json === false) {
+            throw new RuntimeException('Restore staging payload not found.');
+        }
+        @unlink($path);
+
+        $payload = json_decode($json, true);
+        if (!is_array($payload) || !isset($payload['encrypted_data'], $payload['encryption_key'])) {
+            throw new RuntimeException('Restore staging payload is invalid.');
+        }
+
+        $encryptedData = base64_decode((string)$payload['encrypted_data'], true);
+        if ($encryptedData === false) {
+            throw new RuntimeException('Restore staging payload data is invalid.');
+        }
+
+        return [
+            'encrypted_data' => $encryptedData,
+            'encryption_key' => (string)$payload['encryption_key'],
+            'context' => is_array($payload['context'] ?? null) ? $payload['context'] : [],
+        ];
+    }
+
+    private function path(string $token): string
+    {
+        if (!preg_match('/^[a-f0-9]{48}$/', $token)) {
+            throw new RuntimeException('Invalid restore staging token.');
+        }
+
+        return $this->directory . DIRECTORY_SEPARATOR . $token . '.json';
+    }
+}

--- a/app/src/Services/RestoreStagingService.php
+++ b/app/src/Services/RestoreStagingService.php
@@ -151,7 +151,7 @@ class RestoreStagingService
     private function stagingEncryptionKey(): string
     {
         $configuredKey = getenv('RESTORE_STAGING_KEY');
-        $key = $configuredKey === false ? Security::getSalt() : (string)$configuredKey;
+        $key = is_string($configuredKey) && $configuredKey !== '' ? $configuredKey : Security::getSalt();
         if (strlen($key) < 32) {
             $key = str_pad($key, 32, '0');
         }

--- a/app/src/Services/RestoreStatusService.php
+++ b/app/src/Services/RestoreStatusService.php
@@ -16,7 +16,7 @@ class RestoreStatusService
     private const LOCK_KEY = 'restore.lock';
     private const STATUS_KEY = 'restore.status';
     private const DEFAULT_LOCK_TTL_SECONDS = 1800;
-    private const STALE_PROGRESS_SECONDS = 180;
+    private const STALE_PROGRESS_SECONDS = 900;
 
     /**
      * Acquire restore lock and initialize running status.

--- a/app/src/Services/RestoreStatusService.php
+++ b/app/src/Services/RestoreStatusService.php
@@ -74,12 +74,13 @@ class RestoreStatusService
      */
     public function updateStatus(string $phase, string $message, array $context = []): void
     {
-        $status = $this->getStatus();
+        $locked = $this->refreshLock($context);
+        $status = $this->readStatus();
         $status = array_merge(
             $status,
             $context,
             [
-                'locked' => $this->isLocked(),
+                'locked' => $locked,
                 'status' => 'running',
                 'phase' => $phase,
                 'message' => $message,
@@ -88,6 +89,26 @@ class RestoreStatusService
         );
 
         $this->writeStatus($status);
+    }
+
+    /**
+     * Extend the active restore lock TTL while preserving ownership context.
+     *
+     * @param array<string, mixed> $context
+     */
+    public function refreshLock(array $context = [], ?int $ttlSeconds = null): bool
+    {
+        $lock = $this->readActiveLock();
+        if ($lock === null) {
+            return false;
+        }
+
+        $seconds = max(60, (int)($ttlSeconds ?? self::DEFAULT_LOCK_TTL_SECONDS));
+        Cache::write(self::LOCK_KEY, array_merge($lock, $context, [
+            'expires_at' => $this->isoAfterSeconds($seconds),
+        ]), self::CACHE_CONFIG);
+
+        return true;
     }
 
     /**

--- a/app/src/Services/RestoreStatusService.php
+++ b/app/src/Services/RestoreStatusService.php
@@ -91,6 +91,27 @@ class RestoreStatusService
     }
 
     /**
+     * Append a user-visible restore log line to the shared status payload.
+     */
+    public function appendLog(string $message): void
+    {
+        $status = $this->readStatus();
+        $log = $status['log'] ?? [];
+        if (!is_array($log)) {
+            $log = [];
+        }
+
+        $log[] = [
+            'timestamp' => $this->nowIso(),
+            'message' => $message,
+        ];
+
+        $status['log'] = array_slice($log, -100);
+        $status['updated_at'] = $this->nowIso();
+        $this->writeStatus($status);
+    }
+
+    /**
      * Mark restore status as completed and clear lock.
      *
      * @param array<string, mixed> $context
@@ -112,12 +133,16 @@ class RestoreStatusService
                 'updated_at' => $now,
                 'completed_at' => $now,
                 'expires_at' => null,
+                'maintenance_required' => false,
             ],
         ));
     }
 
     /**
      * Mark restore status as failed and clear lock.
+     *
+     * Set maintenance_required when the database may have been partially reset
+     * and normal controllers should not run against the current schema.
      *
      * @param array<string, mixed> $context
      */
@@ -138,6 +163,7 @@ class RestoreStatusService
                 'updated_at' => $now,
                 'completed_at' => $now,
                 'expires_at' => null,
+                'maintenance_required' => (bool)($context['maintenance_required'] ?? false),
             ],
         ));
     }
@@ -172,6 +198,7 @@ class RestoreStatusService
                 $status['updated_at'] = $now;
                 $status['completed_at'] = $now;
                 $status['expires_at'] = null;
+                $status['maintenance_required'] = true;
                 $this->writeStatus($status);
 
                 return $status;
@@ -194,6 +221,7 @@ class RestoreStatusService
             $status['updated_at'] = $now;
             $status['completed_at'] = $now;
             $status['expires_at'] = null;
+            $status['maintenance_required'] = true;
             $this->writeStatus($status);
 
             return $status;
@@ -236,6 +264,9 @@ class RestoreStatusService
             'row_count' => null,
             'rows_processed' => 0,
             'current_table' => null,
+            'queue_job_id' => null,
+            'maintenance_required' => false,
+            'log' => [],
         ];
     }
 

--- a/app/templates/Backups/index.php
+++ b/app/templates/Backups/index.php
@@ -255,6 +255,12 @@ $restoreIsLocked = !empty($restoreStatus['locked']);
                     </div>
                     <div class="fw-semibold" data-backup-restore-status-target="modalMessage"><?= __('Waiting to start restore...') ?></div>
                     <div class="small text-muted mt-2" data-backup-restore-status-target="modalDetails"><?= __('No active restore.') ?></div>
+                    <section class="mt-3" aria-labelledby="restore-progress-log-heading">
+                        <h6 id="restore-progress-log-heading"><?= __('Restore Log') ?></h6>
+                        <ol class="small mb-0 ps-3" data-backup-restore-status-target="modalLog" aria-live="polite" aria-relevant="additions text">
+                            <li><?= __('No restore log entries have been written yet.') ?></li>
+                        </ol>
+                    </section>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" data-backup-restore-status-target="modalClose"><?= __('Close') ?></button>

--- a/app/tests/TestCase/Services/BackupServiceTest.php
+++ b/app/tests/TestCase/Services/BackupServiceTest.php
@@ -77,8 +77,32 @@ class BackupServiceTest extends TestCase
         $this->assertSame(1, $notValidatedConstraintCount);
         $this->assertContains('ROLLBACK TO SAVEPOINT kmp_fk_validate_0', $connection->queries);
         $this->assertContains(
-            'ALTER TABLE "awards_recommendations_events" ADD CONSTRAINT "awards_recommendations_events_recommendation_id_fkey" FOREIGN KEY (recommendation_id) REFERENCES awards_recommendations(id) NOT VALID',
+            'ALTER TABLE "awards_recommendations_events" ADD CONSTRAINT '
+            . '"awards_recommendations_events_recommendation_id_fkey" FOREIGN KEY '
+            . '(recommendation_id) REFERENCES awards_recommendations(id) NOT VALID',
             $connection->queries,
         );
+    }
+
+    public function testImportRejectsObsoleteRowOnlyPayload(): void
+    {
+        $service = new BackupService();
+        $payload = [
+            'meta' => ['version' => 1],
+            'tables' => [],
+        ];
+        $json = json_encode($payload);
+        $this->assertNotFalse($json);
+        $compressed = gzencode($json);
+        $this->assertNotFalse($compressed);
+
+        $method = new ReflectionMethod(BackupService::class, 'encrypt');
+        $method->setAccessible(true);
+        $encrypted = $method->invoke($service, $compressed, 'test-key');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported backup format');
+
+        $service->import($encrypted, 'test-key');
     }
 }

--- a/app/tests/TestCase/Services/BackupServiceTest.php
+++ b/app/tests/TestCase/Services/BackupServiceTest.php
@@ -101,7 +101,29 @@ class BackupServiceTest extends TestCase
         $encrypted = $method->invoke($service, $compressed, 'test-key');
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unsupported backup format');
+        $this->expectExceptionMessage('Unsupported backup format. Regenerate the backup with this KMP release.');
+
+        $service->import($encrypted, 'test-key');
+    }
+
+    public function testImportRejectsMalformedV2PayloadBeforeSchemaReset(): void
+    {
+        $service = new BackupService();
+        $payload = [
+            'meta' => ['version' => 2],
+            'tables' => [],
+        ];
+        $json = json_encode($payload);
+        $this->assertNotFalse($json);
+        $compressed = gzencode($json);
+        $this->assertNotFalse($compressed);
+
+        $method = new ReflectionMethod(BackupService::class, 'encrypt');
+        $method->setAccessible(true);
+        $encrypted = $method->invoke($service, $compressed, 'test-key');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid backup file structure');
 
         $service->import($encrypted, 'test-key');
     }

--- a/app/tests/TestCase/Services/RestoreStagingServiceTest.php
+++ b/app/tests/TestCase/Services/RestoreStagingServiceTest.php
@@ -5,11 +5,18 @@ namespace App\Test\TestCase\Services;
 
 use App\Services\RestoreStagingService;
 use Cake\TestSuite\TestCase;
+use RuntimeException;
 
+/**
+ * Tests restore payload staging and single-use token consumption.
+ */
 class RestoreStagingServiceTest extends TestCase
 {
     private string $directory;
 
+    /**
+     * Create an isolated staging directory for each test.
+     */
     protected function setUp(): void
     {
         parent::setUp();
@@ -19,6 +26,9 @@ class RestoreStagingServiceTest extends TestCase
             . bin2hex(random_bytes(4));
     }
 
+    /**
+     * Remove staged files and the test staging directory.
+     */
     protected function tearDown(): void
     {
         if (is_dir($this->directory)) {
@@ -30,6 +40,9 @@ class RestoreStagingServiceTest extends TestCase
         parent::tearDown();
     }
 
+    /**
+     * Verify staged payloads round-trip once and are deleted after consumption.
+     */
     public function testStageAndConsumeRoundTripDeletesPayload(): void
     {
         $service = new RestoreStagingService($this->directory);
@@ -41,6 +54,7 @@ class RestoreStagingServiceTest extends TestCase
         $this->assertMatchesRegularExpression('/^[a-f0-9]{48}$/', $token);
         $payloadPath = $this->directory . DIRECTORY_SEPARATOR . $token . '.json';
         $this->assertFileExists($payloadPath);
+        $this->assertStringNotContainsString('restore-key', (string)file_get_contents($payloadPath));
 
         $payload = $service->consume($token);
 
@@ -48,5 +62,29 @@ class RestoreStagingServiceTest extends TestCase
         $this->assertSame('restore-key', $payload['encryption_key']);
         $this->assertSame('backup.kmpbackup', $payload['context']['source']);
         $this->assertFileDoesNotExist($payloadPath);
+
+        $this->expectException(RuntimeException::class);
+        $service->consume($token);
+    }
+
+    /**
+     * Keep invalid claimed payloads for troubleshooting instead of deleting them.
+     */
+    public function testConsumeKeepsClaimedPayloadWhenValidationFails(): void
+    {
+        $service = new RestoreStagingService($this->directory);
+        $token = $service->stage('encrypted-bytes', 'restore-key');
+        $payloadPath = $this->directory . DIRECTORY_SEPARATOR . $token . '.json';
+        file_put_contents($payloadPath, '{invalid');
+
+        try {
+            $service->consume($token);
+            $this->fail('Expected corrupt staging payload to fail validation.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('Restore staging payload is invalid.', $e->getMessage());
+        }
+
+        $this->assertFileDoesNotExist($payloadPath);
+        $this->assertCount(1, glob($payloadPath . '.*.claimed') ?: []);
     }
 }

--- a/app/tests/TestCase/Services/RestoreStagingServiceTest.php
+++ b/app/tests/TestCase/Services/RestoreStagingServiceTest.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Test\TestCase\Services;
+
+use App\Services\RestoreStagingService;
+use Cake\TestSuite\TestCase;
+
+class RestoreStagingServiceTest extends TestCase
+{
+    private string $directory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->directory = sys_get_temp_dir()
+            . DIRECTORY_SEPARATOR
+            . 'kmp_restore_staging_test_'
+            . bin2hex(random_bytes(4));
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->directory)) {
+            foreach (glob($this->directory . DIRECTORY_SEPARATOR . '*') ?: [] as $file) {
+                @unlink($file);
+            }
+            @rmdir($this->directory);
+        }
+        parent::tearDown();
+    }
+
+    public function testStageAndConsumeRoundTripDeletesPayload(): void
+    {
+        $service = new RestoreStagingService($this->directory);
+        $token = $service->stage('encrypted-bytes', 'restore-key', [
+            'source' => 'backup.kmpbackup',
+            'actor' => '42',
+        ]);
+
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{48}$/', $token);
+        $payloadPath = $this->directory . DIRECTORY_SEPARATOR . $token . '.json';
+        $this->assertFileExists($payloadPath);
+
+        $payload = $service->consume($token);
+
+        $this->assertSame('encrypted-bytes', $payload['encrypted_data']);
+        $this->assertSame('restore-key', $payload['encryption_key']);
+        $this->assertSame('backup.kmpbackup', $payload['context']['source']);
+        $this->assertFileDoesNotExist($payloadPath);
+    }
+}

--- a/app/tests/TestCase/Services/RestoreStagingServiceTest.php
+++ b/app/tests/TestCase/Services/RestoreStagingServiceTest.php
@@ -41,9 +41,9 @@ class RestoreStagingServiceTest extends TestCase
     }
 
     /**
-     * Verify staged payloads round-trip once and are deleted after consumption.
+     * Verify staged payloads round-trip and remain claimed until success cleanup.
      */
-    public function testStageAndConsumeRoundTripDeletesPayload(): void
+    public function testStageAndConsumeRoundTripRetainsClaimedPayloadUntilDiscard(): void
     {
         $service = new RestoreStagingService($this->directory);
         $token = $service->stage('encrypted-bytes', 'restore-key', [
@@ -62,9 +62,13 @@ class RestoreStagingServiceTest extends TestCase
         $this->assertSame('restore-key', $payload['encryption_key']);
         $this->assertSame('backup.kmpbackup', $payload['context']['source']);
         $this->assertFileDoesNotExist($payloadPath);
+        $this->assertCount(1, glob($payloadPath . '.*.claimed') ?: []);
 
-        $this->expectException(RuntimeException::class);
-        $service->consume($token);
+        $payload = $service->consume($token);
+        $this->assertSame('encrypted-bytes', $payload['encrypted_data']);
+
+        $service->discard($token);
+        $this->assertSame([], glob($payloadPath . '.*.claimed') ?: []);
     }
 
     /**

--- a/app/tests/TestCase/Services/RestoreStatusServiceTest.php
+++ b/app/tests/TestCase/Services/RestoreStatusServiceTest.php
@@ -133,7 +133,7 @@ class RestoreStatusServiceTest extends BaseTestCase
     public function testMarkFailed(): void
     {
         $this->service->acquireLock();
-        $this->service->markFailed('SQL import error');
+        $this->service->markFailed('SQL import error', ['maintenance_required' => true]);
 
         $status = $this->service->getStatus();
         $this->assertFalse($status['locked']);
@@ -141,6 +141,20 @@ class RestoreStatusServiceTest extends BaseTestCase
         $this->assertEquals('failed', $status['phase']);
         $this->assertEquals('SQL import error', $status['message']);
         $this->assertNotNull($status['completed_at']);
+        $this->assertTrue($status['maintenance_required']);
+    }
+
+    public function testAppendLogKeepsUserVisibleEntries(): void
+    {
+        $this->service->acquireLock();
+        $this->service->appendLog('Decrypting backup file.');
+        $this->service->appendLog('Resetting database schema.');
+
+        $status = $this->service->getStatus();
+        $this->assertCount(2, $status['log']);
+        $this->assertEquals('Decrypting backup file.', $status['log'][0]['message']);
+        $this->assertEquals('Resetting database schema.', $status['log'][1]['message']);
+        $this->assertArrayHasKey('timestamp', $status['log'][0]);
     }
 
     public function testMarkCompletedReleasesLock(): void
@@ -181,12 +195,14 @@ class RestoreStatusServiceTest extends BaseTestCase
             'source' => 'manual',
             'backup_id' => 'backup-123',
             'actor' => 'admin@test.com',
+            'queue_job_id' => 42,
         ]);
 
         $status = $this->service->getStatus();
         $this->assertEquals('manual', $status['source']);
         $this->assertEquals('backup-123', $status['backup_id']);
         $this->assertEquals('admin@test.com', $status['actor']);
+        $this->assertEquals(42, $status['queue_job_id']);
     }
 
     public function testAcquireLockMinimumTtl(): void
@@ -209,6 +225,7 @@ class RestoreStatusServiceTest extends BaseTestCase
             'source', 'backup_id', 'actor',
             'table_count', 'tables_processed',
             'row_count', 'rows_processed', 'current_table',
+            'queue_job_id', 'maintenance_required', 'log',
         ];
 
         foreach ($expectedKeys as $key) {

--- a/app/tests/js/controllers/backup-restore-status-controller.test.js
+++ b/app/tests/js/controllers/backup-restore-status-controller.test.js
@@ -29,6 +29,7 @@ describe('BackupRestoreStatusController', () => {
                     <span data-backup-restore-status-target="modalBadge" class="badge"></span>
                     <span data-backup-restore-status-target="modalMessage"></span>
                     <span data-backup-restore-status-target="modalDetails"></span>
+                    <ol data-backup-restore-status-target="modalLog"></ol>
                     <div data-backup-restore-status-target="modalSpinner" class="d-none"></div>
                     <button data-backup-restore-status-target="modalClose">Close</button>
                 </div>
@@ -61,6 +62,8 @@ describe('BackupRestoreStatusController', () => {
         controller.hasModalMessageTarget = true;
         controller.modalDetailsTarget = document.querySelector('[data-backup-restore-status-target="modalDetails"]');
         controller.hasModalDetailsTarget = true;
+        controller.modalLogTarget = document.querySelector('[data-backup-restore-status-target="modalLog"]');
+        controller.hasModalLogTarget = true;
         controller.modalSpinnerTarget = document.querySelector('[data-backup-restore-status-target="modalSpinner"]');
         controller.hasModalSpinnerTarget = true;
         controller.modalCloseTargets = Array.from(document.querySelectorAll('[data-backup-restore-status-target="modalClose"]'));
@@ -86,7 +89,7 @@ describe('BackupRestoreStatusController', () => {
     test('has correct static targets', () => {
         expect(BackupRestoreStatusController.targets).toEqual(expect.arrayContaining([
             'panel', 'badge', 'message', 'details', 'modal',
-            'modalBadge', 'modalMessage', 'modalDetails', 'modalSpinner', 'modalClose'
+            'modalBadge', 'modalMessage', 'modalDetails', 'modalLog', 'modalSpinner', 'modalClose'
         ]));
     });
 
@@ -129,6 +132,25 @@ describe('BackupRestoreStatusController', () => {
         expect(result.state).toBe('failed');
         expect(result.badgeClass).toBe('bg-danger');
         expect(result.panelClass).toBe('alert-danger');
+    });
+
+    test('renderModal writes restore log entries', () => {
+        controller.modalInstance = { show: jest.fn() };
+
+        controller.renderModal({
+            badgeLabel: 'restoring',
+            badgeClass: 'bg-info',
+            message: 'Restore running.',
+            details: 'Rows: 10',
+            showSpinner: true,
+            log: [
+                { timestamp: '2026-06-23T18:03:31+00:00', message: 'Decrypting backup file.' },
+                { timestamp: '2026-06-23T18:03:32+00:00', message: 'Resetting database schema.' },
+            ],
+        });
+
+        expect(controller.modalLogTarget.textContent).toContain('Decrypting backup file.');
+        expect(controller.modalLogTarget.textContent).toContain('Resetting database schema.');
     });
 
     test('normalizeStatus includes source and table details', () => {


### PR DESCRIPTION
This change updates backup restore so old-release backups can be restored safely and then migrated forward to the currently running code. The backup payload now carries a database-neutral schema manifest, allowing restore to reset the live database structure before importing data and running the normal migration flow.

## Summary

- Adds schema manifest export and schema reset services for MySQL/Postgres-compatible restore flows.
- Changes restore to run as a staged, tokenized background CLI runner instead of holding a web request open during destructive schema changes.
- Adds restore maintenance middleware so normal traffic receives a lightweight restore-in-progress response while status and health endpoints remain available.
- Updates CLI restore and the backup restore Stimulus controller to follow the new reset/import/migrate flow.
- Fixes local Docker build context rules so the dev app image can copy its Docker entrypoint and config files.

## Notes for reviewers

The current row-only backup format is treated as obsolete because there are no production backups in that format. Restore state and staged web restore payloads are stored outside the database so the process can survive dropping and recreating database tables.

## Validation

- `php -l` on changed PHP files
- `node --check app/assets/js/controllers/backup-restore-status-controller.js`
- `git diff --check`
- Focused PHPUnit was not run because `app/vendor/bin/phpunit` is not installed in this worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Backup restores now run asynchronously in the background using a staged restore flow.
  * Added a maintenance gate during restore/DB reset, returning 503/500 with restore details (including enhanced `/health` handling).
  * Restore payloads now include versioned schema manifest data for more reliable restores.
  * Restore modal now displays a live “Restore Log”.

* **Improvements**
  * Stalled restore detection increased from 3 to 15 minutes.
  * Clients receive HTTP 202 while restores continue in the background.

* **Chores**
  * Updated Docker ignore rules.
  * Added/expanded test coverage for staging, status logging, and payload validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->